### PR TITLE
Filtrering på temaNytt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseConsumer.kt
@@ -149,7 +149,7 @@ class JournalføringHendelseConsumer(val hendelsesloggRepository: HendelsesloggR
     }
 
     private fun erGyldigHendelsetype(hendelseRecord: JournalfoeringHendelseRecord): Boolean {
-        return GYLDIGE_HENDELSE_TYPER.contains(hendelseRecord.hendelsesType.toString())
+        return GYLDIGE_HENDELSE_TYPER.contains(hendelseRecord.hendelsesType.toString()) && hendelseRecord.temaNytt == "BAR"
     }
 
     fun CharSequence.toStringOrNull(): String? {

--- a/src/test/kotlin/no/nav/familie/ba/mottak/config/KafkaErrorHandlerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/config/KafkaErrorHandlerTest.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ba.mottak.config
+
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.kafka.listener.MessageListenerContainer
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KafkaErrorHandlerTest {
+
+    @MockK(relaxed = true)
+    lateinit var container: MessageListenerContainer;
+
+    @MockK(relaxed = true)
+    lateinit var consumer: Consumer<*, *>
+
+    @InjectMockKs
+    lateinit var errorHandler: KafkaErrorHandler
+
+    @BeforeEach
+    internal fun setUp() {
+        MockKAnnotations.init(this)
+        clearAllMocks()
+    }
+
+    @Test
+    fun `skal stoppe container hvis man mottar feil med en tom liste med records`() {
+        assertThatThrownBy { errorHandler.handle(RuntimeException("Feil i test"), emptyList(), consumer, container) }
+                .hasMessageContaining("Feil i test")
+                .hasCauseExactlyInstanceOf(RuntimeException::class.java)
+
+        verify(exactly = 1) { container.stop() }
+    }
+
+    @Test
+    fun `skal stoppe container hvis man mottar feil med en liste med records`() {
+        val consumerRecord = ConsumerRecord("topic", 1, 1, 1, "record")
+        assertThatThrownBy { errorHandler.handle(RuntimeException("Feil i test"), listOf(consumerRecord), consumer, container) }
+                .hasMessageContaining("Feil i test")
+                .hasCauseExactlyInstanceOf(RuntimeException::class.java)
+
+        verify(exactly = 1) { container.stop() }
+    }
+
+    @Test
+    fun `skal stoppe container hvis man mottar feil hvor liste med records er null`() {
+        val consumerRecord = ConsumerRecord("topic", 1, 1, 1, "record")
+        assertThatThrownBy { errorHandler.handle(RuntimeException("Feil i test"), null, consumer, container) }
+                .hasMessageContaining("Feil i test")
+                .hasCauseExactlyInstanceOf(RuntimeException::class.java)
+
+        verify(exactly = 1) { container.stop() }
+    }
+}


### PR DESCRIPTION
Begrenser filtrering på tema info man får i hendelseRecord. Minsker sjansen for dupliseringer, færre kall til saf, og dermed færre alerts.