### PR TITLE
Endret måten behandlingstema settes på oppgave.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapper.kt
@@ -48,10 +48,8 @@ class OppgaveMapper(private val aktørClient: AktørClient) {
         }
 
         return when (journalpost.dokumenter.firstOrNull { it.brevkode != null }?.brevkode) {
-            "NAV 33-00.07" -> Behandlingstema.OrdinærBarnetrygd.value
-            "NAV 33-00.09" -> Behandlingstema.UtvidetBarnetrygd.value
             "NAV 33-00.15" -> null
-            else -> journalpost.behandlingstema
+            else -> Behandlingstema.OrdinærBarnetrygd.value
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.mottak.config.ApplicationConfig
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstema
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.log.NavHttpHeaders
@@ -48,10 +49,10 @@ class OppgaveClientTest {
     fun `Opprett journalføringsoppgave skal returnere oppgave id`() {
         MDC.put("callId", "opprettJournalføringsoppgave")
         stubFor(post(urlEqualTo("/api/oppgave"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                                objectMapper.writeValueAsString(success(OppgaveResponse(oppgaveId = 1234))))))
+                        .willReturn(aResponse()
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(
+                                                    objectMapper.writeValueAsString(success(OppgaveResponse(oppgaveId = 1234))))))
         mockkStatic(LocalDateTime::class)
         every { LocalDateTime.now() } returns LocalDateTime.of(2020, 4, 1, 0, 0)
 
@@ -60,12 +61,12 @@ class OppgaveClientTest {
 
         assertThat(opprettOppgaveResponse.oppgaveId).isEqualTo(1234)
         verify(anyRequestedFor(anyUrl())
-                .withHeader(NavHttpHeaders.NAV_CALL_ID.asString(), equalTo("opprettJournalføringsoppgave"))
-                .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("familie-ba-mottak"))
-                .withRequestBody(equalToJson(forventetOpprettOppgaveRequestJson(journalpostId = "1234567",
-                        oppgavetype = "Journalføring",
-                        behandlingstema = "behandlingstemaFraJournalpost",
-                        beskrivelse = "Tittel"))))
+                       .withHeader(NavHttpHeaders.NAV_CALL_ID.asString(), equalTo("opprettJournalføringsoppgave"))
+                       .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("familie-ba-mottak"))
+                       .withRequestBody(equalToJson(forventetOpprettOppgaveRequestJson(journalpostId = "1234567",
+                                                                                       oppgavetype = "Journalføring",
+                                                                                       behandlingstema = Behandlingstema.OrdinærBarnetrygd.value,
+                                                                                       beskrivelse = "Tittel"))))
     }
 
     @Test
@@ -73,10 +74,10 @@ class OppgaveClientTest {
     fun `Opprett behandleSak-oppgave skal returnere oppgave id`() {
         MDC.put("callId", "opprettJournalføringsoppgave")
         stubFor(post(urlEqualTo("/api/oppgave"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                                objectMapper.writeValueAsString(success(OppgaveResponse(oppgaveId = 1234))))))
+                        .willReturn(aResponse()
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(
+                                                    objectMapper.writeValueAsString(success(OppgaveResponse(oppgaveId = 1234))))))
         mockkStatic(LocalDateTime::class)
         every { LocalDateTime.now() } returns LocalDateTime.of(2020, 4, 1, 0, 0)
 
@@ -85,22 +86,22 @@ class OppgaveClientTest {
 
         assertThat(opprettOppgaveResponse.oppgaveId).isEqualTo(1234)
         verify(anyRequestedFor(anyUrl())
-                .withHeader(NavHttpHeaders.NAV_CALL_ID.asString(), equalTo("opprettJournalføringsoppgave"))
-                .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("familie-ba-mottak"))
-                .withRequestBody(equalToJson(
-                        forventetOpprettOppgaveRequestJson(journalpostId = "1234567",
-                                oppgavetype = "BehandleSak",
-                                behandlingstema = "behandlingstemaFraJournalpost",
-                                beskrivelse = "Tittel"))))
+                       .withHeader(NavHttpHeaders.NAV_CALL_ID.asString(), equalTo("opprettJournalføringsoppgave"))
+                       .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("familie-ba-mottak"))
+                       .withRequestBody(equalToJson(
+                               forventetOpprettOppgaveRequestJson(journalpostId = "1234567",
+                                                                  oppgavetype = "BehandleSak",
+                                                                  behandlingstema = Behandlingstema.OrdinærBarnetrygd.value,
+                                                                  beskrivelse = "Tittel"))))
     }
 
     @Test
     @Tag("integration")
     fun `Opprett oppgave skal kaste feil hvis response er ugyldig`() {
         stubFor(post(urlEqualTo("/api/oppgave"))
-                .willReturn(aResponse()
-                        .withStatus(500)
-                        .withBody(objectMapper.writeValueAsString(Ressurs.failure<String>("test")))))
+                        .willReturn(aResponse()
+                                            .withStatus(500)
+                                            .withBody(objectMapper.writeValueAsString(Ressurs.failure<String>("test")))))
 
         assertThatThrownBy {
             oppgaveClient.opprettJournalføringsoppgave(journalPost)
@@ -127,10 +128,10 @@ class OppgaveClientTest {
     @Tag("integration")
     fun `Finn oppgaver skal returnere liste med 1 oppgave`() {
         stubFor(get(urlEqualTo("/api/oppgave?tema=BAR&journalpostId=1234567&oppgavetype=JFR"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                                objectMapper.writeValueAsString(success(listOf(OppgaveDto(id = 1234)))))))
+                        .willReturn(aResponse()
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(
+                                                    objectMapper.writeValueAsString(success(listOf(OppgaveDto(id = 1234)))))))
 
         val oppgaveListe = oppgaveClient.finnOppgaver(journalPost.journalpostId, Oppgavetype.Journalføring)
 
@@ -142,10 +143,10 @@ class OppgaveClientTest {
     @Tag("integration")
     fun `Finn oppgaver skal returnere tom liste`() {
         stubFor(get(urlEqualTo("/api/oppgave?tema=BAR&journalpostId=1234567&oppgavetype=JFR"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                                objectMapper.writeValueAsString(success(emptyList<OppgaveDto>())))))
+                        .willReturn(aResponse()
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(
+                                                    objectMapper.writeValueAsString(success(emptyList<OppgaveDto>())))))
 
         val oppgaveListe = oppgaveClient.finnOppgaver(journalPost.journalpostId, Oppgavetype.Journalføring)
 
@@ -158,40 +159,40 @@ class OppgaveClientTest {
                                                    behandlingstema: String,
                                                    beskrivelse: String): String {
         return "{\n" +
-                "  \"ident\": {\n" +
-                "    \"ident\": \"1234567891011\",\n" +
-                "    \"type\": \"Aktør\"\n" +
-                "  },\n" +
-                "  \"enhetsnummer\": \"9999\",\n" +
-                "  \"saksId\": null,\n" +
-                "  \"journalpostId\": \"$journalpostId\",\n" +
-                "  \"tema\": \"BAR\",\n" +
-                "  \"oppgavetype\": \"$oppgavetype\",\n" +
-                "  \"behandlingstema\": \"$behandlingstema\",\n" +
-                "  \"tilordnetRessurs\": null,\n" +
-                "  \"fristFerdigstillelse\": \"2020-04-01\",\n" +
-                "  \"aktivFra\": \"${LocalDate.now()}\",\n" +
-                "  \"beskrivelse\": \"${beskrivelse}\",\n" +
-                "  \"prioritet\": \"NORM\",\n" +
-                "  \"behandlingstype\": null\n" +
-                "}"
+               "  \"ident\": {\n" +
+               "    \"ident\": \"1234567891011\",\n" +
+               "    \"type\": \"Aktør\"\n" +
+               "  },\n" +
+               "  \"enhetsnummer\": \"9999\",\n" +
+               "  \"saksId\": null,\n" +
+               "  \"journalpostId\": \"$journalpostId\",\n" +
+               "  \"tema\": \"BAR\",\n" +
+               "  \"oppgavetype\": \"$oppgavetype\",\n" +
+               "  \"behandlingstema\": \"$behandlingstema\",\n" +
+               "  \"tilordnetRessurs\": null,\n" +
+               "  \"fristFerdigstillelse\": \"2020-04-01\",\n" +
+               "  \"aktivFra\": \"${LocalDate.now()}\",\n" +
+               "  \"beskrivelse\": \"${beskrivelse}\",\n" +
+               "  \"prioritet\": \"NORM\",\n" +
+               "  \"behandlingstype\": null\n" +
+               "}"
     }
 
     companion object {
         private val journalPost = Journalpost("1234567",
-                Journalposttype.I,
-                Journalstatus.MOTTATT,
-                "tema",
-                "behandlingstemaFraJournalpost",
-                null,
-                Bruker("1234567891011", BrukerIdType.AKTOERID),
-                "9999",
-                "kanal",
-                listOf(
-                        DokumentInfo("Tittel",
-                                "NAV- 99.00.07",
-                                null,
-                                null)
-                ))
+                                              Journalposttype.I,
+                                              Journalstatus.MOTTATT,
+                                              "tema",
+                                              "behandlingstemaFraJournalpost",
+                                              null,
+                                              Bruker("1234567891011", BrukerIdType.AKTOERID),
+                                              "9999",
+                                              "kanal",
+                                              listOf(
+                                                      DokumentInfo("Tittel",
+                                                                   "NAV- 99.00.07",
+                                                                   null,
+                                                                   null)
+                                              ))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -82,24 +82,9 @@ class OppgaveMapperTest(
         assertEquals(Behandlingstema.OrdinærBarnetrygd.value, oppgave.behandlingstema)
     }
 
-    @Test
-    fun `skal sette behandlingstema Utvidet`() {
-        val oppgaveMapper = OppgaveMapper(mockAktørClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.Journalføring,
-                                                         journalpostClient.hentJournalpost("123")
-                                                                 .copy(dokumenter = listOf(DokumentInfo(
-                                                                         tittel = null,
-                                                                         brevkode = "NAV 33-00.09",
-                                                                         dokumentstatus = null,
-                                                                         dokumentvarianter = null))
-                                                                 )
-        )
-        assertNull(oppgave.behandlingstype)
-        assertEquals(Behandlingstema.UtvidetBarnetrygd.value, oppgave.behandlingstema)
-    }
 
     @Test
-    fun `skal sette behandlingstema fra journalpost`() {
+    fun `skal sette behandlingstema Ordinær uavhengig av journalpost`() {
         val oppgaveMapper = OppgaveMapper(mockAktørClient)
         val oppgave = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.Journalføring,
                                                          journalpostClient.hentJournalpost("123")
@@ -111,7 +96,7 @@ class OppgaveMapperTest(
                                                                        behandlingstema = "btema"
                                                                  )
         )
-        assertEquals("btema", oppgave.behandlingstema)
+        assertEquals(Behandlingstema.OrdinærBarnetrygd.value, oppgave.behandlingstema)
     }
 
     @Test


### PR DESCRIPTION
Løser TEA-1276 som medfører følgende regelsett for å sette behandlingstema på oppgave:

Hvis søker har d-nummer: sett behandlingstema= ab0058 (EØS)
Hvis søker ikke har d-nummer: vurder brevkoden på hoveddokumentet

- Brevkode NAV 33-00.15 => behandlingstema null, behandlingstype ae0106 (Utland)
- Alle andre tilfeller  =>  behandlingstema ab0180 (Ordinær), behandlingstype null