### PR TITLE
Avgjøre om dokument skal behandles i BA-sak eller Infotrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
@@ -2,9 +2,7 @@ package no.nav.familie.ba.mottak.integrasjoner
 
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
+import no.nav.familie.kontrakter.felles.oppgave.*
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -13,7 +11,6 @@ import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
-import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
 private val logger = LoggerFactory.getLogger(OppgaveClient::class.java)
@@ -41,23 +38,17 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
     }
 
     @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delay = 5000))
-    fun finnOppgaver(journalpostId: String, oppgavetype: Oppgavetype?): List<OppgaveDto> {
-        val uriBuilder = UriComponentsBuilder.fromUri(integrasjonUri)
-                .pathSegment("oppgave")
-                .queryParam("tema", "BAR")
-                .queryParam("journalpostId", journalpostId)
-
-        if (oppgavetype != null){
-            uriBuilder.queryParam("oppgavetype", oppgavetype.value)
-        }
-
-        val uri = uriBuilder.build().toUri()
+    fun finnOppgaver(journalpostId: String, oppgavetype: Oppgavetype?): List<Oppgave> {
         logger.info("Søker etter aktive oppgaver for $journalpostId")
+        val uri = URI.create("$integrasjonUri/oppgave/v4")
+        val request = FinnOppgaveRequest(journalpostId = journalpostId,
+                                         tema = Tema.BAR,
+                                         oppgavetype = oppgavetype)
 
         return Result.runCatching {
-            getForEntity<Ressurs<List<OppgaveDto>>>(uri)
+            postForEntity<Ressurs<FinnOppgaveResponseDto>>(uri, request)
         }.fold(
-                onSuccess = { response -> assertGyldig(response) },
+                onSuccess = { response -> assertGyldig(response).oppgaver },
                 onFailure = {
                     throw IntegrasjonException("GET $uri feilet ved henting av oppgaver",
                                                it,
@@ -70,6 +61,7 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
 
     private fun responseFra(uri: URI, request: OpprettOppgaveRequest): OppgaveResponse {
         return Result.runCatching {
+            logger.info("Sender OpprettOppgaveRequest med beskrivelse: ${request.beskrivelse}")
             postForEntity<Ressurs<OppgaveResponse>>(uri, request)
         }.fold(
                 onSuccess = { response -> assertGyldig(response) },

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
@@ -23,7 +23,7 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
 
     fun opprettJournalføringsoppgave(journalpost: Journalpost, beskrivelse: String? = null): OppgaveResponse {
         logger.info("Oppretter journalføringsoppgave for papirsøknad")
-        val uri = URI.create("$integrasjonUri/oppgave")
+        val uri = URI.create("$integrasjonUri/oppgave/opprett")
         val request = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.Journalføring, journalpost, beskrivelse)
 
         return responseFra(uri, request)
@@ -31,7 +31,7 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
 
     fun opprettBehandleSakOppgave(journalpost: Journalpost): OppgaveResponse {
         logger.info("Oppretter \"Behandle sak\"-oppgave for digital søknad")
-        val uri = URI.create("$integrasjonUri/oppgave")
+        val uri = URI.create("$integrasjonUri/oppgave/opprett")
         val request = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.BehandleSak, journalpost)
 
         return responseFra(uri, request)

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
@@ -4,7 +4,7 @@ import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgave
+import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -24,10 +24,10 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
                                            private val oppgaveMapper: OppgaveMapper)
     : AbstractRestClient(restOperations, "integrasjon") {
 
-    fun opprettJournalføringsoppgave(journalpost: Journalpost): OppgaveResponse {
+    fun opprettJournalføringsoppgave(journalpost: Journalpost, beskrivelse: String? = null): OppgaveResponse {
         logger.info("Oppretter journalføringsoppgave for papirsøknad")
         val uri = URI.create("$integrasjonUri/oppgave")
-        val request = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.Journalføring, journalpost)
+        val request = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.Journalføring, journalpost, beskrivelse)
 
         return responseFra(uri, request)
     }
@@ -68,7 +68,7 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
     }
 
 
-    private fun responseFra(uri: URI, request: OpprettOppgave): OppgaveResponse {
+    private fun responseFra(uri: URI, request: OpprettOppgaveRequest): OppgaveResponse {
         return Result.runCatching {
             postForEntity<Ressurs<OppgaveResponse>>(uri, request)
         }.fold(

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapper.kt
@@ -9,21 +9,22 @@ import org.springframework.stereotype.Service
 class OppgaveMapper(private val aktørClient: AktørClient) {
 
     fun mapTilOpprettOppgave(oppgavetype: Oppgavetype,
-                             journalpost: Journalpost): OpprettOppgave {
+                             journalpost: Journalpost,
+                             beskrivelse: String? = null): OpprettOppgaveRequest {
         val ident = tilOppgaveIdent(journalpost, oppgavetype)
-        return OpprettOppgave(ident = ident,
+        return OpprettOppgaveRequest(ident = ident,
                 saksId = journalpost.sak?.fagsakId,
                 journalpostId = journalpost.journalpostId,
                 tema = Tema.BAR,
                 oppgavetype = oppgavetype,
                 fristFerdigstillelse = fristFerdigstillelse(),
-                beskrivelse = hentHovedDokumentTittel(journalpost) ?: "",
+                beskrivelse = beskrivelse ?: hentHovedDokumentTittel(journalpost) ?: "",
                 enhetsnummer = journalpost.journalforendeEnhet,
                 behandlingstema = hentBehandlingstema(journalpost),
                 behandlingstype = hentBehandlingstype(journalpost))
     }
 
-    private fun tilOppgaveIdent(journalpost: Journalpost, oppgavetype: Oppgavetype): OppgaveIdent? {
+    private fun tilOppgaveIdent(journalpost: Journalpost, oppgavetype: Oppgavetype): OppgaveIdentV2? {
         if (journalpost.bruker == null) {
             when (oppgavetype) {
                 Oppgavetype.BehandleSak -> throw error("Journalpost ${journalpost.journalpostId} mangler bruker")
@@ -33,10 +34,10 @@ class OppgaveMapper(private val aktørClient: AktørClient) {
 
         return when (journalpost.bruker.type) {
             BrukerIdType.FNR -> {
-                OppgaveIdent(ident = aktørClient.hentAktørId(journalpost.bruker.id), type = IdentType.Aktør)
+                OppgaveIdentV2(ident = aktørClient.hentAktørId(journalpost.bruker.id), gruppe = IdentGruppe.AKTOERID)
             }
-            BrukerIdType.ORGNR -> OppgaveIdent(ident = journalpost.bruker.id, type = IdentType.Organisasjon)
-            BrukerIdType.AKTOERID -> OppgaveIdent(ident = journalpost.bruker.id, type = IdentType.Aktør)
+            BrukerIdType.ORGNR -> OppgaveIdentV2(ident = journalpost.bruker.id, gruppe = IdentGruppe.ORGNR)
+            BrukerIdType.AKTOERID -> OppgaveIdentV2(ident = journalpost.bruker.id, gruppe = IdentGruppe.AKTOERID)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -51,11 +51,11 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
 
     fun hentPågåendeSakStatus(personIdent: String): RestPågåendeSakSøk {
         val uri = URI.create("$sakServiceUri/fagsaker/sok/ba-sak-og-infotrygd")
-        return kotlin.runCatching {
+        return runCatching {
             postForEntity<Ressurs<RestPågåendeSakSøk>>(uri, mapOf("personIdent" to personIdent))!!
         }.fold(
                 onSuccess = {it.data ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
-                onFailure = { throw IntegrasjonException("Feil ved henting sak opplysninger fra ba-sak.", it, uri, personIdent) }
+                onFailure = { throw IntegrasjonException("Feil ved henting av sak opplysninger fra ba-sak.", it, uri, personIdent) }
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -48,6 +48,21 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
             onFailure = { throw IntegrasjonException("Feil ved henting av saksnummer fra ba-sak.", it, uri, personIdent) }
         )
     }
+
+    fun hentPågåendeSakStatus(personIdent: String): RestPågåendeSakSøk {
+        val uri = URI.create("$sakServiceUri/fagsaker/sok/ba-sak-og-infotrygd")
+        return kotlin.runCatching {
+            postForEntity<Ressurs<RestPågåendeSakSøk>>(uri, mapOf("personIdent" to personIdent))!!
+        }.fold(
+                onSuccess = {it.data ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
+                onFailure = { throw IntegrasjonException("Feil ved henting sak opplysninger fra ba-sak.", it, uri, personIdent) }
+        )
+    }
 }
 
 data class RestFagsak(val id: Long)
+
+data class RestPågåendeSakSøk(
+        val harPågåendeSakIBaSak: Boolean,
+        val harPågåendeSakIInfotrygd: Boolean
+)

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -42,7 +42,7 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
     fun hentSaksnummer(personIdent: String): String {
         val uri = URI.create("$sakServiceUri/fagsaker")
         return runCatching {
-            postForEntity<Ressurs<RestFagsak>>(uri, mapOf("personIdent" to personIdent))!!
+            postForEntity<Ressurs<RestFagsak>>(uri, mapOf("personIdent" to personIdent))
         }.fold(
             onSuccess = { it.data?.id?.toString() ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
             onFailure = { throw IntegrasjonException("Feil ved henting av saksnummer fra ba-sak.", it, uri, personIdent) }
@@ -52,7 +52,7 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
     fun hentPågåendeSakStatus(personIdent: String): RestPågåendeSakSøk {
         val uri = URI.create("$sakServiceUri/fagsaker/sok/ba-sak-og-infotrygd")
         return runCatching {
-            postForEntity<Ressurs<RestPågåendeSakSøk>>(uri, mapOf("personIdent" to personIdent))!!
+            postForEntity<Ressurs<RestPågåendeSakSøk>>(uri, mapOf("personIdent" to personIdent))
         }.fold(
                 onSuccess = { it.data?.let(this::valider) ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
                 onFailure = { throw IntegrasjonException("Feil ved henting av sak opplysninger fra ba-sak.", it, uri, personIdent) }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTask.kt
@@ -28,7 +28,6 @@ class OppdaterOgFerdigstillJournalpostTask(private val journalpostClient: Journa
 
         sakClient.hentPågåendeSakStatus(tilPersonIdent(journalpost.bruker!!)).apply {
             if (harPågåendeSakIInfotrygd) {
-                assert(!harPågåendeSakIBaSak)
                 log.info("Bruker har sak i Infotrygd. Overlater journalføring til BRUT001 og skipper opprettelse av BehandleSak-" +
                          "oppgave for journalpost ${journalpost.journalpostId}")
                 return

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTask.kt
@@ -59,7 +59,7 @@ class OpprettJournalføringOppgaveTask(private val journalpostClient: Journalpos
     private fun sakssystemMarkering(journalpost: Journalpost): String? {
         return sakClient.hentPågåendeSakStatus(tilPersonIdent(journalpost.bruker!!)).let { bruker ->
             when {
-                bruker.harPågåendeSakIBaSak -> "Må løses i BA-sak. Bruker har en pågående sak i BA-sak.".also { assert(!bruker.harPågåendeSakIInfotrygd) }
+                bruker.harPågåendeSakIBaSak -> "Må løses i BA-sak. Bruker har en pågående sak i BA-sak."
                 bruker.harPågåendeSakIInfotrygd -> "Må løses i Gosys. Bruker har en pågående sak i Infotrygd"
                 else -> null // trenger ingen form for markering. Kan løses av begge systemer
             }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.mottak.task
 
+import no.nav.familie.ba.mottak.config.FeatureToggleService
 import no.nav.familie.ba.mottak.integrasjoner.*
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -17,7 +18,8 @@ class OpprettJournalføringOppgaveTask(private val journalpostClient: Journalpos
                                       private val oppgaveClient: OppgaveClient,
                                       private val sakClient: SakClient,
                                       private val aktørClient: AktørClient,
-                                      private val taskRepository: TaskRepository) : AsyncTaskStep {
+                                      private val taskRepository: TaskRepository,
+                                      private val feature: FeatureToggleService) : AsyncTaskStep {
 
     val log: Logger = LoggerFactory.getLogger(OpprettJournalføringOppgaveTask::class.java)
 
@@ -57,6 +59,8 @@ class OpprettJournalføringOppgaveTask(private val journalpostClient: Journalpos
     }
 
     private fun sakssystemMarkering(journalpost: Journalpost): String? {
+        if (!feature.isEnabled("familie-ba-mottak.journalhendelse.fagsystem.fordeling", true)) return null
+
         return sakClient.hentPågåendeSakStatus(tilPersonIdent(journalpost.bruker!!)).let { bruker ->
             when {
                 bruker.harPågåendeSakIBaSak -> "Må løses i BA-sak. Bruker har en pågående sak i BA-sak."

--- a/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ba.mottak.integrasjoner.*
 import no.nav.familie.ba.mottak.task.OppdaterOgFerdigstillJournalpostTask
 import no.nav.familie.ba.mottak.task.OpprettJournalføringOppgaveTask
 import no.nav.familie.ba.mottak.task.SendTilSakTask
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
@@ -131,6 +132,7 @@ class JournalføringHendelseServiceTest {
                               sak = null)
 
         every { mockFeatureToggleService.isEnabled(any()) } returns true
+        every { mockFeatureToggleService.isEnabled(any(), true) } returns true
     }
 
     @Test
@@ -225,7 +227,8 @@ class JournalføringHendelseServiceTest {
                 mockOppgaveClient,
                 sakClient,
                 aktørClient,
-                mockTaskRepository)
+                mockTaskRepository,
+                mockFeatureToggleService)
 
         task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_UTGÅENDE_DOKUMENT))
 
@@ -242,17 +245,18 @@ class JournalføringHendelseServiceTest {
         } returns listOf()
         every {
             mockOppgaveClient.finnOppgaver(JOURNALPOST_UTGÅENDE_DOKUMENT, Oppgavetype.Journalføring)
-        } returns listOf(OppgaveDto(123))
+        } returns listOf(Oppgave(123))
         every {
             mockOppgaveClient.finnOppgaver(JOURNALPOST_PAPIRSØKNAD, Oppgavetype.Fordeling)
-        } returns listOf(OppgaveDto(123))
+        } returns listOf(Oppgave(123))
 
         val task = OpprettJournalføringOppgaveTask(
                 mockJournalpostClient,
                 mockOppgaveClient,
                 sakClient,
                 aktørClient,
-                mockTaskRepository)
+                mockTaskRepository,
+                mockFeatureToggleService)
         task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_UTGÅENDE_DOKUMENT))
         task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_PAPIRSØKNAD))
 
@@ -268,7 +272,8 @@ class JournalføringHendelseServiceTest {
                 mockOppgaveClient,
                 sakClient,
                 aktørClient,
-                mockTaskRepository)
+                mockTaskRepository,
+                mockFeatureToggleService)
 
         Assertions.assertThrows(IllegalStateException::class.java) {
             task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_FERDIGSTILT))

--- a/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -34,6 +34,12 @@ class JournalføringHendelseServiceTest {
     @MockK
     lateinit var mockOppgaveClient: OppgaveClient
 
+    @MockK
+    lateinit var sakClient: SakClient
+
+    @MockK
+    lateinit var aktørClient: AktørClient
+
     @MockK(relaxed = true)
     lateinit var mockTaskRepository: TaskRepository
 
@@ -204,9 +210,20 @@ class JournalføringHendelseServiceTest {
             mockTaskRepository.saveAndFlush(any<Task>())
         } returns null
 
+        every {
+            aktørClient.hentPersonident(any())
+        } returns "12345678910"
+
+        every {
+            sakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = false,
+                                     harPågåendeSakIInfotrygd = false)
+
         val task = OpprettJournalføringOppgaveTask(
                 mockJournalpostClient,
                 mockOppgaveClient,
+                sakClient,
+                aktørClient,
                 mockTaskRepository)
 
         task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_UTGÅENDE_DOKUMENT))
@@ -231,6 +248,8 @@ class JournalføringHendelseServiceTest {
         val task = OpprettJournalføringOppgaveTask(
                 mockJournalpostClient,
                 mockOppgaveClient,
+                sakClient,
+                aktørClient,
                 mockTaskRepository)
         task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_UTGÅENDE_DOKUMENT))
         task.doTask(Task.nyTask(SendTilSakTask.TASK_STEP_TYPE, JOURNALPOST_PAPIRSØKNAD))
@@ -245,6 +264,8 @@ class JournalføringHendelseServiceTest {
         val task = OpprettJournalføringOppgaveTask(
                 mockJournalpostClient,
                 mockOppgaveClient,
+                sakClient,
+                aktørClient,
                 mockTaskRepository)
 
         Assertions.assertThrows(IllegalStateException::class.java) {

--- a/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -202,8 +202,9 @@ class JournalføringHendelseServiceTest {
             mockOppgaveClient.finnOppgaver(any(), any())
         } returns listOf()
 
+        val sakssystemMarkering = slot<String>()
         every {
-            mockOppgaveClient.opprettJournalføringsoppgave(any())
+            mockOppgaveClient.opprettJournalføringsoppgave(any(), capture(sakssystemMarkering))
         } returns OppgaveResponse(1)
 
         every {
@@ -216,7 +217,7 @@ class JournalføringHendelseServiceTest {
 
         every {
             sakClient.hentPågåendeSakStatus(any())
-        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = false,
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = true,
                                      harPågåendeSakIInfotrygd = false)
 
         val task = OpprettJournalføringOppgaveTask(
@@ -231,6 +232,7 @@ class JournalføringHendelseServiceTest {
         verify(exactly = 1) {
             mockTaskRepository.saveAndFlush(any<Task>())
         }
+        assertThat(sakssystemMarkering.captured).contains("Må løses i BA-sak")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
@@ -161,7 +161,7 @@ class OppgaveClientTest {
         return "{\n" +
                "  \"ident\": {\n" +
                "    \"ident\": \"1234567891011\",\n" +
-               "    \"type\": \"Aktør\"\n" +
+               "    \"gruppe\": \"AKTOERID\"\n" +
                "  },\n" +
                "  \"enhetsnummer\": \"9999\",\n" +
                "  \"saksId\": null,\n" +

--- a/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
@@ -46,7 +46,7 @@ class OppgaveClientTest {
     @Tag("integration")
     fun `Opprett journalføringsoppgave skal returnere oppgave id`() {
         MDC.put("callId", "opprettJournalføringsoppgave")
-        stubFor(post(urlEqualTo("/api/oppgave"))
+        stubFor(post(urlEqualTo("/api/oppgave/opprett"))
                         .willReturn(aResponse()
                                             .withHeader("Content-Type", "application/json")
                                             .withBody(
@@ -71,7 +71,7 @@ class OppgaveClientTest {
     @Tag("integration")
     fun `Opprett behandleSak-oppgave skal returnere oppgave id`() {
         MDC.put("callId", "opprettJournalføringsoppgave")
-        stubFor(post(urlEqualTo("/api/oppgave"))
+        stubFor(post(urlEqualTo("/api/oppgave/opprett"))
                         .willReturn(aResponse()
                                             .withHeader("Content-Type", "application/json")
                                             .withBody(
@@ -96,7 +96,7 @@ class OppgaveClientTest {
     @Test
     @Tag("integration")
     fun `Opprett oppgave skal kaste feil hvis response er ugyldig`() {
-        stubFor(post(urlEqualTo("/api/oppgave"))
+        stubFor(post(urlEqualTo("/api/oppgave/opprett"))
                         .willReturn(aResponse()
                                             .withStatus(500)
                                             .withBody(objectMapper.writeValueAsString(Ressurs.failure<String>("test")))))
@@ -104,12 +104,12 @@ class OppgaveClientTest {
         assertThatThrownBy {
             oppgaveClient.opprettJournalføringsoppgave(journalPost)
         }.isInstanceOf(IntegrasjonException::class.java)
-                .hasMessageContaining("Error mot http://localhost:28085/api/oppgave status=500 body={")
+                .hasMessageContaining("Error mot http://localhost:28085/api/oppgave/opprett status=500 body={")
 
         assertThatThrownBy {
             oppgaveClient.opprettBehandleSakOppgave(journalPost)
         }.isInstanceOf(IntegrasjonException::class.java)
-                .hasMessageContaining("Error mot http://localhost:28085/api/oppgave status=500 body={")
+                .hasMessageContaining("Error mot http://localhost:28085/api/oppgave/opprett status=500 body={")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClientTest.kt
@@ -9,9 +9,7 @@ import no.nav.familie.ba.mottak.DevLauncher
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
 import no.nav.familie.kontrakter.felles.objectMapper
-import no.nav.familie.kontrakter.felles.oppgave.Behandlingstema
-import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.*
 import no.nav.familie.log.NavHttpHeaders
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -127,11 +125,14 @@ class OppgaveClientTest {
     @Test
     @Tag("integration")
     fun `Finn oppgaver skal returnere liste med 1 oppgave`() {
-        stubFor(get(urlEqualTo("/api/oppgave?tema=BAR&journalpostId=1234567&oppgavetype=JFR"))
+        stubFor(post(urlEqualTo("/api/oppgave/v4"))
                         .willReturn(aResponse()
                                             .withHeader("Content-Type", "application/json")
                                             .withBody(
-                                                    objectMapper.writeValueAsString(success(listOf(OppgaveDto(id = 1234)))))))
+                                                    objectMapper.writeValueAsString(success(
+                                                            FinnOppgaveResponseDto(antallTreffTotalt = 1,
+                                                                                   oppgaver = listOf(Oppgave(id = 1234)))
+                                                    )))))
 
         val oppgaveListe = oppgaveClient.finnOppgaver(journalPost.journalpostId, Oppgavetype.Journalføring)
 
@@ -142,11 +143,14 @@ class OppgaveClientTest {
     @Test
     @Tag("integration")
     fun `Finn oppgaver skal returnere tom liste`() {
-        stubFor(get(urlEqualTo("/api/oppgave?tema=BAR&journalpostId=1234567&oppgavetype=JFR"))
+        stubFor(post(urlEqualTo("/api/oppgave/v4"))
                         .willReturn(aResponse()
                                             .withHeader("Content-Type", "application/json")
                                             .withBody(
-                                                    objectMapper.writeValueAsString(success(emptyList<OppgaveDto>())))))
+                                                    objectMapper.writeValueAsString(success(
+                                                            FinnOppgaveResponseDto(antallTreffTotalt = 0,
+                                                                                   oppgaver = emptyList())
+                                                    )))))
 
         val oppgaveListe = oppgaveClient.finnOppgaver(journalPost.journalpostId, Oppgavetype.Journalføring)
 

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTaskTest.kt
@@ -1,0 +1,139 @@
+package no.nav.familie.ba.mottak.task
+
+import io.mockk.*
+import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.task.OppdaterOgFerdigstillJournalpostTask.Companion.TASK_STEP_TYPE
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpServerErrorException
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OppdaterOgFerdigstillJournalpostTaskTest {
+
+    private val mockJournalpostClient: JournalpostClient = mockk()
+    private val mockDokarkivClient: DokarkivClient = mockk(relaxed = true)
+    private val mockSakClient: SakClient = mockk()
+    private val mockAktørClient: AktørClient = mockk()
+    private val mockTaskRepository: TaskRepository = mockk(relaxed = true)
+
+    private val taskStep = OppdaterOgFerdigstillJournalpostTask(mockJournalpostClient,
+                                                                mockDokarkivClient,
+                                                                mockSakClient,
+                                                                mockAktørClient,
+                                                                mockTaskRepository)
+
+
+    @BeforeEach
+    internal fun setUp() {
+        clearAllMocks()
+        //Inngående digital, Mottatt
+        every {
+            mockJournalpostClient.hentJournalpost(any())
+        } returns Journalpost(journalpostId = JOURNALPOST_ID,
+                              journalposttype = Journalposttype.I,
+                              journalstatus = Journalstatus.MOTTATT,
+                              bruker = Bruker("123456789012", BrukerIdType.AKTOERID),
+                              tema = "BAR",
+                              kanal = "NAV_NO",
+                              behandlingstema = null,
+                              dokumenter = null,
+                              journalforendeEnhet = null,
+                              sak = null)
+
+        every {
+            mockTaskRepository.saveAndFlush(any<Task>())
+        } returns null
+
+        every {
+            mockAktørClient.hentPersonident(any())
+        } returns "12345678910"
+    }
+
+    @Test
+    fun `Skal oppdatere og ferdigstille journalpost og deretter lagre ny OpprettBehandleSakOppgaveTask`() {
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = true,
+                                     harPågåendeSakIInfotrygd = false)
+
+        every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        val task = slot<Task>()
+
+        verify(exactly = 1) {
+            mockDokarkivClient.oppdaterJournalpostSak(any(), FAGSAK_ID)
+            mockDokarkivClient.ferdigstillJournalpost(JOURNALPOST_ID)
+            mockTaskRepository.save(capture(task))
+        }
+        Assertions.assertThat(task.captured.taskStepType).isEqualTo(OpprettBehandleSakOppgaveTask.TASK_STEP_TYPE)
+    }
+
+    @Test
+    fun `Skal returnere uten å journalføre når bruker ikke har sak i BA-sak`() {
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = false,
+                                     harPågåendeSakIInfotrygd = false)
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        verify(exactly = 0) {
+            mockDokarkivClient.oppdaterJournalpostSak(any(), any())
+            mockDokarkivClient.ferdigstillJournalpost(any())
+            mockTaskRepository.save(any())
+        }
+    }
+
+    @Test
+    fun `Skal returnere uten å journalføre når bruker har sak i Infotrygd`() {
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = true,
+                                     harPågåendeSakIInfotrygd = true)
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        verify(exactly = 0) {
+            mockDokarkivClient.oppdaterJournalpostSak(any(), any())
+            mockDokarkivClient.ferdigstillJournalpost(any())
+            mockTaskRepository.save(any())
+        }
+    }
+
+    @Test
+    fun `Skal lagre ny OpprettJournalføringOppgaveTask hvis automatisk journalføring feiler`() {
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = true,
+                                     harPågåendeSakIInfotrygd = false)
+
+        every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
+
+        every {
+            mockDokarkivClient.ferdigstillJournalpost(any())
+        } throws (HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR))
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        val task = slot<Task>()
+
+        verify(exactly = 1) {
+            mockTaskRepository.save(capture(task))
+        }
+        Assertions.assertThat(task.captured.taskStepType).isEqualTo(OpprettJournalføringOppgaveTask.TASK_STEP_TYPE)
+    }
+
+    companion object {
+        private const val JOURNALPOST_ID = "222"
+        private const val FAGSAK_ID = "1"
+    }
+
+}

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTaskTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.mottak.task
 
 import io.mockk.*
+import no.nav.familie.ba.mottak.config.FeatureToggleService
 import no.nav.familie.ba.mottak.integrasjoner.*
 import no.nav.familie.ba.mottak.task.OppdaterOgFerdigstillJournalpostTask.Companion.TASK_STEP_TYPE
 import no.nav.familie.prosessering.domene.Task
@@ -21,12 +22,14 @@ class OppdaterOgFerdigstillJournalpostTaskTest {
     private val mockSakClient: SakClient = mockk()
     private val mockAktørClient: AktørClient = mockk()
     private val mockTaskRepository: TaskRepository = mockk(relaxed = true)
+    private val mockFeatureToggleService: FeatureToggleService = mockk(relaxed = true)
 
     private val taskStep = OppdaterOgFerdigstillJournalpostTask(mockJournalpostClient,
                                                                 mockDokarkivClient,
                                                                 mockSakClient,
                                                                 mockAktørClient,
-                                                                mockTaskRepository)
+                                                                mockTaskRepository,
+                                                                mockFeatureToggleService)
 
 
     @BeforeEach
@@ -53,6 +56,10 @@ class OppdaterOgFerdigstillJournalpostTaskTest {
         every {
             mockAktørClient.hentPersonident(any())
         } returns "12345678910"
+
+        every {
+            mockFeatureToggleService.isEnabled(any(), true)
+        } returns true
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTaskTest.kt
@@ -1,0 +1,111 @@
+package no.nav.familie.ba.mottak.task
+
+import io.mockk.*
+import no.nav.familie.ba.mottak.hendelser.JournalføringHendelseServiceTest
+import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.task.OpprettJournalføringOppgaveTask.Companion.TASK_STEP_TYPE
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OpprettJournalføringOppgaveTaskTest {
+
+    private val mockJournalpostClient: JournalpostClient = mockk()
+    private val mockOppgaveClient: OppgaveClient = mockk()
+    private val mockSakClient: SakClient = mockk()
+    private val mockAktørClient: AktørClient = mockk()
+    private val mockTaskRepository: TaskRepository = mockk(relaxed = true)
+
+    private val taskStep = OpprettJournalføringOppgaveTask(mockJournalpostClient,
+                                                           mockOppgaveClient,
+                                                           mockSakClient,
+                                                           mockAktørClient,
+                                                           mockTaskRepository)
+
+
+    @BeforeAll
+    internal fun setUp() {
+        //Inngående papirsøknad, Mottatt
+        every {
+            mockJournalpostClient.hentJournalpost(any())
+        } returns Journalpost(journalpostId = JournalføringHendelseServiceTest.JOURNALPOST_PAPIRSØKNAD,
+                              journalposttype = Journalposttype.I,
+                              journalstatus = Journalstatus.MOTTATT,
+                              bruker = Bruker("123456789012", BrukerIdType.AKTOERID),
+                              tema = "BAR",
+                              kanal = "SKAN_NETS",
+                              behandlingstema = null,
+                              dokumenter = null,
+                              journalforendeEnhet = null,
+                              sak = null)
+
+        every {
+            mockOppgaveClient.finnOppgaver(any(), any())
+        } returns listOf()
+
+        every {
+            mockTaskRepository.saveAndFlush(any<Task>())
+        } returns null
+
+        every {
+            mockAktørClient.hentPersonident(any())
+        } returns "12345678910"
+    }
+
+    @Test
+    fun `Oppretter oppgave med beskrivelse "Må løses i BA-sak" hvis bruker på journalpost har sak der fra før`() {
+        val sakssystemMarkering = slot<String>()
+        every {
+            mockOppgaveClient.opprettJournalføringsoppgave(any(), capture(sakssystemMarkering))
+        } returns OppgaveResponse(1)
+
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = true,
+                                     harPågåendeSakIInfotrygd = false)
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        Assertions.assertThat(sakssystemMarkering.captured).contains("Må løses i BA-sak")
+    }
+
+    @Test
+    fun `Oppretter oppgave med beskrivelse "Må løses i Gosys" hvis bruker har sak i Infotrygd fra før`() {
+        val sakssystemMarkering = slot<String>()
+        every {
+            mockOppgaveClient.opprettJournalføringsoppgave(any(), capture(sakssystemMarkering))
+        } returns OppgaveResponse(1)
+
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = false,
+                                     harPågåendeSakIInfotrygd = true)
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        Assertions.assertThat(sakssystemMarkering.captured).contains("Må løses i Gosys")
+    }
+
+    @Test
+    fun `Oppretter oppgave uten markering av sakssytem når bruker ikke har sak fra før`() {
+        every {
+            mockOppgaveClient.opprettJournalføringsoppgave(any())
+        } returns OppgaveResponse(1)
+
+        every {
+            mockSakClient.hentPågåendeSakStatus(any())
+        } returns RestPågåendeSakSøk(harPågåendeSakIBaSak = false,
+                                     harPågåendeSakIInfotrygd = false)
+
+        taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+
+        verify(exactly = 1) {
+            mockOppgaveClient.opprettJournalføringsoppgave(any(), beskrivelse = null)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/OpprettJournalføringOppgaveTaskTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.mottak.task
 
 import io.mockk.*
+import no.nav.familie.ba.mottak.config.FeatureToggleService
 import no.nav.familie.ba.mottak.hendelser.JournalføringHendelseServiceTest
 import no.nav.familie.ba.mottak.integrasjoner.*
 import no.nav.familie.ba.mottak.task.OpprettJournalføringOppgaveTask.Companion.TASK_STEP_TYPE
@@ -20,12 +21,14 @@ class OpprettJournalføringOppgaveTaskTest {
     private val mockSakClient: SakClient = mockk()
     private val mockAktørClient: AktørClient = mockk()
     private val mockTaskRepository: TaskRepository = mockk(relaxed = true)
+    private val mockFeatureToggleService: FeatureToggleService = mockk(relaxed = true)
 
     private val taskStep = OpprettJournalføringOppgaveTask(mockJournalpostClient,
                                                            mockOppgaveClient,
                                                            mockSakClient,
                                                            mockAktørClient,
-                                                           mockTaskRepository)
+                                                           mockTaskRepository,
+                                                           mockFeatureToggleService)
 
 
     @BeforeAll
@@ -55,6 +58,10 @@ class OpprettJournalføringOppgaveTaskTest {
         every {
             mockAktørClient.hentPersonident(any())
         } returns "12345678910"
+
+        every {
+            mockFeatureToggleService.isEnabled(any(), true)
+        } returns true
     }
 
     @Test


### PR DESCRIPTION
Henter informasjon om hvorvidt bruker har pågående sak i ba-sak eller infotrygd ved behandling av innkommende journalposter og implementerer flytene beskrevet i [Tea-2000](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2000).

Erstattet OpprettOppgave (deprecated) med OpprettOppgaveRequest i OppgaveMapper.