### PR TITLE
Markering av at beh_sak oppgaven skal løses i basak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/JournalhendelseService.kt
@@ -74,7 +74,7 @@ class JournalhendelseService(val journalpostClient: JournalpostClient,
     }
 
     fun CharSequence.toStringOrNull(): String? {
-        return if (!this.isBlank()) this.toString() else null
+        return if (this.isNotBlank()) this.toString() else null
     }
 
 
@@ -115,7 +115,7 @@ class JournalhendelseService(val journalpostClient: JournalpostClient,
     }
 
     private fun behandleNavnoHendelser(journalpost: Journalpost) {
-        if (featureToggleService.isEnabled("familie-ba-mottak.journalhendelse.behsak")) {
+        if (featureToggleService.isEnabled("familie-ba-mottak.journalhendelse.behsak", true)) {
             val metadata = opprettMetadata(journalpost)
             val ferdigstillTask =
                     Task.nyTask(OppdaterOgFerdigstillJournalpostTask.TASK_STEP_TYPE,

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/JournalpostClient.kt
@@ -30,7 +30,7 @@ class JournalpostClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRAS
         logger.debug("henter journalpost med id {}", journalpostId)
         return try {
             val response = getForEntity<Ressurs<Journalpost>>(uri)
-            response?.getDataOrThrow()
+            response.getDataOrThrow()
         } catch (e: RestClientResponseException) {
             logger.warn("Henting av journalpost feilet. Responskode: {}, body: {}", e.rawStatusCode, e.responseBodyAsString)
             throw IllegalStateException("Henting av journalpost med id $journalpostId feilet. Status: " + e.rawStatusCode
@@ -50,7 +50,13 @@ data class Journalpost(val journalpostId: String,
                        val bruker: Bruker? = null,
                        val journalforendeEnhet: String? = null,
                        val kanal: String? = null,
-                       val dokumenter: List<DokumentInfo>? = null)
+                       val dokumenter: List<DokumentInfo>? = null) {
+
+    fun hentHovedDokumentTittel(): String? {
+        if (dokumenter.isNullOrEmpty()) error("Journalpost $journalpostId mangler dokumenter")
+        return dokumenter.firstOrNull { it.brevkode != null }?.tittel
+    }
+}
 
 data class Sak(val arkivsaksnummer: String?,
                var arkivsaksystem: String?,

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveClient.kt
@@ -29,10 +29,10 @@ class OppgaveClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJONE
         return responseFra(uri, request)
     }
 
-    fun opprettBehandleSakOppgave(journalpost: Journalpost): OppgaveResponse {
+    fun opprettBehandleSakOppgave(journalpost: Journalpost, beskrivelse: String? = null): OppgaveResponse {
         logger.info("Oppretter \"Behandle sak\"-oppgave for digital søknad")
         val uri = URI.create("$integrasjonUri/oppgave/opprett")
-        val request = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.BehandleSak, journalpost)
+        val request = oppgaveMapper.mapTilOpprettOppgave(Oppgavetype.BehandleSak, journalpost, beskrivelse)
 
         return responseFra(uri, request)
     }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/OppgaveMapper.kt
@@ -18,7 +18,7 @@ class OppgaveMapper(private val aktørClient: AktørClient) {
                 tema = Tema.BAR,
                 oppgavetype = oppgavetype,
                 fristFerdigstillelse = fristFerdigstillelse(),
-                beskrivelse = beskrivelse ?: hentHovedDokumentTittel(journalpost) ?: "",
+                beskrivelse = beskrivelse ?: journalpost.hentHovedDokumentTittel() ?: "",
                 enhetsnummer = if (journalpost.journalforendeEnhet == "2101") "4806" else journalpost.journalforendeEnhet, //Enhet 2101 er nedlagt. Rutes til 4806
                 behandlingstema = hentBehandlingstema(journalpost),
                 behandlingstype = hentBehandlingstype(journalpost))
@@ -57,10 +57,5 @@ class OppgaveMapper(private val aktørClient: AktørClient) {
     private fun hentBehandlingstype(journalpost: Journalpost): String? {
         if (journalpost.dokumenter.isNullOrEmpty()) error("Journalpost ${journalpost.journalpostId} mangler dokumenter")
         return if (journalpost.dokumenter.any { it.brevkode == "NAV 33-00.15" }) Behandlingstype.Utland.value else null
-    }
-
-    private fun hentHovedDokumentTittel(journalpost: Journalpost): String? {
-        if (journalpost.dokumenter.isNullOrEmpty()) error("Journalpost ${journalpost.journalpostId} mangler dokumenter")
-        return journalpost.dokumenter.firstOrNull { it.brevkode != null }?.tittel
     }
 }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/OppdaterOgFerdigstillJournalpostTask.kt
@@ -82,7 +82,9 @@ class OppdaterOgFerdigstillJournalpostTask(private val journalpostClient: Journa
         val nyTask = Task.nyTask(
                 type = OpprettBehandleSakOppgaveTask.TASK_STEP_TYPE,
                 payload = task.payload,
-                properties = task.metadata
+                properties = task.metadata.apply {
+                    this["fagsystem"] = "BA"
+                }
         )
         taskRepository.save(nyTask)
     }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/OpprettBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/OpprettBehandleSakOppgaveTask.kt
@@ -25,8 +25,12 @@ class OpprettBehandleSakOppgaveTask(private val journalpostClient: JournalpostCl
         if (journalpost.journalstatus == Journalstatus.JOURNALFOERT) {
             val oppgaver = oppgaveClient.finnOppgaver(journalpost.journalpostId, null)
             if (oppgaver.isNullOrEmpty()) {
+                var beskrivelse = journalpost.hentHovedDokumentTittel()
+                if (task.metadata["fagsystem"] == "BA") {
+                    beskrivelse = "Må behandles i BA-sak.\n $beskrivelse"
+                }
                 task.metadata["oppgaveId"] =
-                        "${oppgaveClient.opprettBehandleSakOppgave(journalpost).oppgaveId}"
+                        "${oppgaveClient.opprettBehandleSakOppgave(journalpost, beskrivelse).oppgaveId}"
                 taskRepository.saveAndFlush(task)
             } else {
                 throw error("Det eksister minst 1 åpen oppgave på journalpost ${task.payload}")

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/OpprettBehandleSakOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/OpprettBehandleSakOppgaveTaskTest.kt
@@ -1,0 +1,125 @@
+package no.nav.familie.ba.mottak.task
+
+import io.mockk.*
+import no.nav.familie.ba.mottak.hendelser.JournalføringHendelseServiceTest
+import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.task.OpprettJournalføringOppgaveTask.Companion.TASK_STEP_TYPE
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OpprettBehandleSakOppgaveTaskTest {
+
+    private val mockJournalpostClient: JournalpostClient = mockk()
+    private val mockOppgaveClient: OppgaveClient = mockk()
+    private val mockTaskRepository: TaskRepository = mockk(relaxed = true)
+
+    private val taskStep = OpprettBehandleSakOppgaveTask(mockJournalpostClient, mockOppgaveClient, mockTaskRepository)
+
+    @BeforeAll
+    internal fun setUp() {
+        every {
+            mockOppgaveClient.finnOppgaver(any(), any())
+        } returns listOf()
+
+        every {
+            mockTaskRepository.saveAndFlush(any())
+        } returns null
+    }
+
+    @Test
+    fun `Skal kaste feil hvis journalpost ikke er journalført`() {
+        every {
+            mockJournalpostClient.hentJournalpost(any())
+        } returns lagTestJournalpost(Journalstatus.MOTTATT)
+
+
+        assertThatThrownBy {
+            taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+        }.hasMessage("Kan ikke opprette oppgave før tilhørende journalpost 111 er ferdigstilt")
+    }
+
+    @Test
+    fun `Skal kaste feil hvis det alt er en åpen oppgave`() {
+        every {
+            mockJournalpostClient.hentJournalpost(any())
+        } returns lagTestJournalpost(Journalstatus.JOURNALFOERT)
+
+        every {
+            mockOppgaveClient.finnOppgaver(JournalføringHendelseServiceTest.JOURNALPOST_PAPIRSØKNAD, null)
+        } returns listOf(Oppgave())
+
+
+        assertThatThrownBy {
+            taskStep.doTask(Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId"))
+        }.hasMessage("Det eksister minst 1 åpen oppgave på journalpost mockJournalpostId")
+    }
+
+    @Test
+    fun `Skal opprette behandle sak oppgave og beskrivelse lik tittel på hoveddokument`() {
+        val journalpost = lagTestJournalpost(Journalstatus.JOURNALFOERT)
+        every {
+            mockJournalpostClient.hentJournalpost(any())
+        } returns journalpost
+
+        every {
+            mockOppgaveClient.finnOppgaver(JournalføringHendelseServiceTest.JOURNALPOST_PAPIRSØKNAD, null)
+        } returns emptyList()
+
+        every {
+            mockOppgaveClient.opprettBehandleSakOppgave(journalpost, "Tittel")
+        } returns OppgaveResponse(123)
+
+
+        val task = Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId")
+        taskStep.doTask(task)
+
+        assertThat(task.metadata["oppgaveId"]).isEqualTo("123")
+
+    }
+
+
+    @Test
+    fun `Skal opprette behandle sak oppgave, beskrivelse lik tittel på hoveddokument og markere at den skal behandles i fagsystem BA-sak`() {
+        val journalpost = lagTestJournalpost(Journalstatus.JOURNALFOERT)
+        every {
+            mockJournalpostClient.hentJournalpost(any())
+        } returns journalpost
+
+        every {
+            mockOppgaveClient.finnOppgaver(JournalføringHendelseServiceTest.JOURNALPOST_PAPIRSØKNAD, null)
+        } returns emptyList()
+
+        every {
+            mockOppgaveClient.opprettBehandleSakOppgave(journalpost, "Må behandles i BA-sak.\n Tittel")
+        } returns OppgaveResponse(321)
+
+
+        val task = Task.nyTask(TASK_STEP_TYPE, payload = "mockJournalpostId")
+        task.metadata["fagsystem"] = "BA"
+        taskStep.doTask(task)
+
+        assertThat(task.metadata["oppgaveId"]).isEqualTo("321")
+
+    }
+
+    private fun lagTestJournalpost(status: Journalstatus) = Journalpost(journalpostId = JournalføringHendelseServiceTest.JOURNALPOST_PAPIRSØKNAD,
+                                                                        journalposttype = Journalposttype.I,
+                                                                        journalstatus = status,
+                                                                        bruker = Bruker("123456789012", BrukerIdType.AKTOERID),
+                                                                        tema = "BAR",
+                                                                        kanal = "NAV_NO",
+                                                                        behandlingstema = null,
+                                                                        dokumenter = listOf(DokumentInfo("Tittel",
+                                                                                           "",
+                                                                                           Dokumentstatus.FERDIGSTILT,
+                                                                                           emptyList())),
+                                                                        journalforendeEnhet = null,
+                                                                        sak = null)
+}


### PR DESCRIPTION
- Enhetstester for OpprettBehandleSak
- tasker med metadata fagsystem = BA vil bli markert med prefix om at de skal løses i BA-sak