### PR TITLE
Bumper spring boot til 2.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.10.RELEASE</version>
+        <version>2.3.6.RELEASE</version>
     </parent>
 
     <properties>
@@ -25,9 +25,9 @@
         <felles.version>1.20201123131335_671787f</felles.version>
         <kontrakter.version>2.0_20201210133152_ac0e089</kontrakter.version>
         <main-class>no.nav.familie.ba.mottak.LauncherKt</main-class>
-        <spring.vault.version>2.2.2.RELEASE</spring.vault.version>
+        <spring.vault.version>2.2.3.RELEASE</spring.vault.version>
         <spring.cloud.version>2.2.6.RELEASE</spring.cloud.version>
-        <token-validation-spring.version>1.3.1</token-validation-spring.version>
+        <token-validation-spring.version>1.3.2</token-validation-spring.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
@@ -191,6 +191,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>4.4.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
Oppdatert til spring boot 2.3.6, pluss et par andre rammeverk. Ny spring krevde hibernate-validator i classpath.