### PR TITLE
Setter versjon av github-app-token-generator til v1

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
       - name: Push Docker image
         run: docker push $IMAGE
-      - uses: navikt/github-app-token-generator@master
+      - uses: navikt/github-app-token-generator@v1
         id: get-token
         with:
           private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}


### PR DESCRIPTION
Fikser Failed to resolve action download info. Error: Unable to resolve action navikt/github-app-token-generator@master, unable to find version master ved bygging.