### PR TITLE
Endrer logging for konsumer til warn

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,5 +36,6 @@
     </root>
 
     <logger name="no.nav.familie" level="INFO"/>
+    <logger name="org.apache.kafka.clients.consumer" level="WARN"/>
 
 </configuration>


### PR DESCRIPTION
Skrur opp logging til WARN for kafka consumer for å redusere evt spamming av logger.