### PR TITLE
Readme-fix for docker / postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Se README i navkafka-docker-compose for mer info om hvordan man kjører den og k
 ## Lokal kjøring med Postgres
 For å kjøre mot lokal postgress så kan man kjøre DevLauncherPostgress.
 ```
-docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -d familie-ba-mottak
+docker run --name familie-ba-mottak -p 5432:5432 -e POSTGRES_PASSWORD=test -d postgres
+docker ps (finn container id)
+docker exec -it <container_id> bash
+psql -U postgres
+CREATE DATABASE "familie-ba-mottak";
 ```
 
 ## Kjøring av e2e tester


### PR DESCRIPTION
Docker skal hente postgres, ikke familie-ba-mottak.
Endrer passord slik at den samsvarer med application-postgres.yaml.
Fjerner postgres som bruker da den er default.

Legger også til stegene som er beskrevet i ba-sak så det er enklere å komme i gang.