### PR TITLE
Bytter fra PDL familierelasjoner til forelderBarnRelasjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/e2e/E2EController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/e2e/E2EController.kt
@@ -35,6 +35,7 @@ class E2EController(private val leesahService: LeesahService,
     val logger: Logger = LoggerFactory.getLogger(E2EController::class.java)
 
 
+
     @PostMapping(path = ["/pdl/foedsel"], consumes = [MediaType.APPLICATION_JSON_VALUE])
     fun pdlHendelseFødsel(@RequestBody personIdenter: List<String>): String {
         logger.info("Oppretter fødselshendelse e2e")

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/PdlClient.kt
@@ -53,7 +53,7 @@ class PdlClient(
             if (!response.harFeil()) {
                 return Result.runCatching {
                     val familierelasjoner: Set<Familierelasjon> =
-                        response.data.person!!.familierelasjoner.map { relasjon ->
+                        response.data.person!!.forelderBarnRelasjon.map { relasjon ->
                             Familierelasjon(
                                 personIdent = PersonIdent(id = relasjon.relatertPersonsIdent),
                                 relasjonsrolle = relasjon.relatertPersonsRolle.name
@@ -197,7 +197,7 @@ data class PdlPerson(val person: PdlPersonData?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlPersonData(
-    val familierelasjoner: List<PdlFamilierelasjon> = emptyList(),
+    val forelderBarnRelasjon: List<PdlForeldreBarnRelasjon> = emptyList(),
     val adressebeskyttelse: List<Adressebeskyttelse> = emptyList(),
     val bostedsadresse: List<Bostedsadresse?> = emptyList(),
     @JsonProperty(value = "doedsfall") val dødsfall: List<Dødsfall> = emptyList(),
@@ -205,7 +205,7 @@ data class PdlPersonData(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class PdlFamilierelasjon(
+data class PdlForeldreBarnRelasjon(
     val relatertPersonsIdent: String,
     val relatertPersonsRolle: Familierelasjonsrolle,
     val minRolleForPerson: Familierelasjonsrolle? = null

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
@@ -37,7 +37,7 @@ class VurderLivshendelseTask(
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue(task.payload, VurderLivshendelseTaskDTO::class.java)
         val pdlPersonData = pdlClient.hentPerson(payload.personIdent, "hentperson-relasjon-dødsfall")
-        val familierelasjon = pdlPersonData.familierelasjoner
+        val familierelasjon = pdlPersonData.forelderBarnRelasjon
         when (payload.type) {
             VurderLivshendelseType.DØDSFALL -> {
                 if (pdlPersonData.dødsfall.firstOrNull()?.dødsdato != null) {

--- a/src/main/resources/pdl/hentperson-med-relasjoner.graphql
+++ b/src/main/resources/pdl/hentperson-med-relasjoner.graphql
@@ -1,5 +1,5 @@
 query($ident: ID!) {person: hentPerson(ident: $ident) {
-    familierelasjoner {
+    forelderBarnRelasjon {
         relatertPersonsIdent,
         relatertPersonsRolle
     }

--- a/src/main/resources/pdl/hentperson-relasjon-dødsfall.graphql
+++ b/src/main/resources/pdl/hentperson-relasjon-dødsfall.graphql
@@ -1,5 +1,5 @@
 query($ident: ID!) {person: hentPerson(ident: $ident) {
-    familierelasjoner {
+    forelderBarnRelasjon {
         relatertPersonsIdent,
         relatertPersonsRolle,
         minRolleForPerson

--- a/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/integrasjoner/PdlClientTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ba.mottak.integrasjoner
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import no.nav.familie.ba.mottak.DevLauncher
 import org.apache.commons.lang3.StringUtils
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -57,9 +56,9 @@ class PdlClientTest {
         )
 
         val pdlPersonData = pdlClient.hentPerson(testIdent, "hentperson-relasjon-dødsfall")
-        assertThat(pdlPersonData.familierelasjoner.size).isEqualTo(1)
-        assertThat(pdlPersonData.familierelasjoner.first().minRolleForPerson).isEqualTo(Familierelasjonsrolle.MOR)
-        assertThat(pdlPersonData.familierelasjoner.first().relatertPersonsRolle).isEqualTo(Familierelasjonsrolle.BARN)
+        assertThat(pdlPersonData.forelderBarnRelasjon.size).isEqualTo(1)
+        assertThat(pdlPersonData.forelderBarnRelasjon.first().minRolleForPerson).isEqualTo(Familierelasjonsrolle.MOR)
+        assertThat(pdlPersonData.forelderBarnRelasjon.first().relatertPersonsRolle).isEqualTo(Familierelasjonsrolle.BARN)
         assertThat(pdlPersonData.dødsfall.first().dødsdato).isEqualTo(LocalDate.of(2021, 1, 14))
         assertThat(pdlPersonData.fødsel.first().fødselsdato).isEqualTo(LocalDate.of(1998, 5, 9))
     }

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTaskTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Behandlingstema
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -71,14 +70,14 @@ class VurderLivshendelseTaskTest {
         every {
             mockPdlClient.hentPerson(PERSONIDENT_BARN,
                                      any())
-        } returns PdlPersonData(familierelasjoner = listOf(PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
-                                                                              relatertPersonsIdent = PERSONIDENT_MOR,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.MOR),
-                                                           PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
-                                                                              relatertPersonsIdent = PERSONIDENT_FAR,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.FAR)),
+        } returns PdlPersonData(forelderBarnRelasjon = listOf(PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
+                                                                                      relatertPersonsIdent = PERSONIDENT_MOR,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.MOR),
+                                                              PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
+                                                                                      relatertPersonsIdent = PERSONIDENT_FAR,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.FAR)),
                                 dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now())),
-        fødsel = listOf(Fødsel(LocalDate.of(1980,8,3))))
+                                fødsel = listOf(Fødsel(LocalDate.of(1980,8,3))))
 
         vurderLivshendelseTask.doTask(Task.nyTask(type = VurderLivshendelseTask.TASK_STEP_TYPE,
                                                   payload = objectMapper.writeValueAsString(VurderLivshendelseTaskDTO(
@@ -101,9 +100,9 @@ class VurderLivshendelseTaskTest {
         every {
             mockPdlClient.hentPerson(PERSONIDENT_MOR,
                                      any())
-        } returns PdlPersonData(familierelasjoner = listOf(PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.MOR,
-                                                                              relatertPersonsIdent = PERSONIDENT_BARN,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.BARN)),
+        } returns PdlPersonData(forelderBarnRelasjon = listOf(PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.MOR,
+                                                                                      relatertPersonsIdent = PERSONIDENT_BARN,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.BARN)),
                                 dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now())))
 
         every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, listOf(PERSONIDENT_BARN)) } returns RestPågåendeSakResponse()
@@ -128,9 +127,9 @@ class VurderLivshendelseTaskTest {
         every {
             mockPdlClient.hentPerson(PERSONIDENT_MOR,
                                      any())
-        } returns PdlPersonData(familierelasjoner = listOf(PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.MOR,
-                                                                              relatertPersonsIdent = PERSONIDENT_BARN,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.BARN)),
+        } returns PdlPersonData(forelderBarnRelasjon = listOf(PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.MOR,
+                                                                                      relatertPersonsIdent = PERSONIDENT_BARN,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.BARN)),
                                 dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now())))
 
         every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, listOf(PERSONIDENT_BARN)) } returns RestPågåendeSakResponse(
@@ -157,9 +156,9 @@ class VurderLivshendelseTaskTest {
         every {
             mockPdlClient.hentPerson(any(),
                                      any())
-        } returns PdlPersonData(familierelasjoner = listOf(PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.MOR,
-                                                                              relatertPersonsIdent = PERSONIDENT_BARN,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.BARN)),
+        } returns PdlPersonData(forelderBarnRelasjon = listOf(PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.MOR,
+                                                                                      relatertPersonsIdent = PERSONIDENT_BARN,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.BARN)),
                                 dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now())))
 
         every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, listOf(PERSONIDENT_BARN)) } returns RestPågåendeSakResponse(
@@ -192,12 +191,12 @@ class VurderLivshendelseTaskTest {
         every {
             mockPdlClient.hentPerson(PERSONIDENT_BARN,
                                      any())
-        } returns PdlPersonData(familierelasjoner = listOf(PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
-                                                                              relatertPersonsIdent = PERSONIDENT_MOR,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.MOR),
-                                                           PdlFamilierelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
-                                                                              relatertPersonsIdent = PERSONIDENT_FAR,
-                                                                              relatertPersonsRolle = Familierelasjonsrolle.FAR)),
+        } returns PdlPersonData(forelderBarnRelasjon = listOf(PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
+                                                                                      relatertPersonsIdent = PERSONIDENT_MOR,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.MOR),
+                                                              PdlForeldreBarnRelasjon(minRolleForPerson = Familierelasjonsrolle.BARN,
+                                                                                      relatertPersonsIdent = PERSONIDENT_FAR,
+                                                                                      relatertPersonsRolle = Familierelasjonsrolle.FAR)),
                                 dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now())),
                                 fødsel = listOf(Fødsel(LocalDate.now().minusYears(12))))
 

--- a/src/test/resources/pdl/mock-hentperson-relasjon-dødsfall.json
+++ b/src/test/resources/pdl/mock-hentperson-relasjon-dødsfall.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "person": {
-      "familierelasjoner": [
+      "forelderBarnRelasjon": [
         {
           "relatertPersonsIdent": "32345678901",
           "relatertPersonsRolle": "BARN",

--- a/src/test/resources/pdl/mockPersonResponse.json
+++ b/src/test/resources/pdl/mockPersonResponse.json
@@ -36,7 +36,7 @@
           "ukjentBosted": null
         }
       ],
-      "familierelasjoner": [
+      "forelderBarnRelasjon": [
         {
           "relatertPersonsIdent": "32345678901",
           "relatertPersonsRolle": "BARN"


### PR DESCRIPTION
familierelasjoner er deprikert og bytter navn til forelderBarnRelasjon. Bytter til forelderBarnRelasjon som har akkurat samme info.