### PR TITLE
(fix) Deploy pull request branch istedenfor master i preprod workflow

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -1,6 +1,6 @@
 name: Build-Deploy-Preprod
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
 env:

--- a/.github/workflows/build-dependabot.yml
+++ b/.github/workflows/build-dependabot.yml
@@ -1,14 +1,14 @@
 name: Build-Deploy-Preprod
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened, ready_for_review ]
-  workflow_dispatch:
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ba-mottak:${{ github.sha }}
   IMAGE_UTEN_TAG: docker.pkg.github.com/navikt/familie-ba-mottak/familie-ba-mottak
+
 jobs:
   deploy-to-dev:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     name: Bygg app/image, push til github, deploy til dev-fss
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-dependabot.yml
+++ b/.github/workflows/build-dependabot.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   deploy-to-dev:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    name: Bygg app/image, push til github, deploy til dev-fss
+    name: Dependabot-bygg
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/build-dependabot.yml
+++ b/.github/workflows/build-dependabot.yml
@@ -1,7 +1,7 @@
 name: Build-Deploy-Preprod
 on:
   pull_request_target:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [ labeled ]
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ba-mottak:${{ github.sha }}
   IMAGE_UTEN_TAG: docker.pkg.github.com/navikt/familie-ba-mottak/familie-ba-mottak

--- a/.github/workflows/build-dependabot.yml
+++ b/.github/workflows/build-dependabot.yml
@@ -1,4 +1,4 @@
-name: Build-Deploy-Preprod
+name: Build-Dependabot
 on:
   pull_request_target:
     types: [ labeled ]


### PR DESCRIPTION
Endre workflow trigger siden `pull_request_target` bruker base branch (master) i deploy, så når man deployer en PR deployer man bare forrige merge/commit til master istedenfor det man faktisk vil teste. I tillegg ser det ut som `pull_request_target` har mindre beskyttelse av secrets enn `pull_request` ref https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target