### PR TITLE
Tar i bruk endepunktet som erstatter "sok/ba-sak-og-infotrygd" i sakClient

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/domene/hendelser/PdlHendelse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/domene/hendelser/PdlHendelse.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ba.mottak.domene.hendelser
 import java.time.LocalDate
 
 data class PdlHendelse(val hendelseId: String,
+                       val gjeldendeAktørId: String,
                        val offset: Long,
                        val opplysningstype: String,
                        val endringstype: String,
@@ -14,8 +15,5 @@ data class PdlHendelse(val hendelseId: String,
     ) {
 
         // TODO: Skal gjøres tydeligere og mer robust.
-        fun hentAktørId() = personIdenter.first { it.length == 13 }
-
-        // TODO: Ditto.
         fun hentPersonident() = personIdenter.first { it.length == 11 }
     }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/e2e/E2EController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/e2e/E2EController.kt
@@ -42,6 +42,7 @@ class E2EController(private val leesahService: LeesahService,
         val hendelseId = UUID.randomUUID().toString()
         val pdlHendelse = PdlHendelse(
                 offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = personIdenter.first { it.length == 13 },
                 hendelseId = hendelseId,
                 personIdenter = personIdenter,
                 endringstype = LeesahService.OPPRETTET,
@@ -58,6 +59,7 @@ class E2EController(private val leesahService: LeesahService,
         val hendelseId = UUID.randomUUID().toString()
         val pdlHendelse = PdlHendelse(
                 offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = personIdenter.first { it.length == 13 },
                 hendelseId = hendelseId,
                 personIdenter = personIdenter,
                 endringstype = LeesahService.OPPRETTET,

--- a/src/main/kotlin/no/nav/familie/ba/mottak/e2e/E2EController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/e2e/E2EController.kt
@@ -16,9 +16,14 @@ import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.kafka.support.Acknowledgment
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 import kotlin.random.Random
 import kotlin.random.nextUInt
 
@@ -70,6 +75,22 @@ class E2EController(private val leesahService: LeesahService,
         return hendelseId
     }
 
+    @PostMapping(path = ["/pdl/utflytting"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun pdlHendelseUtflytting(@RequestBody personIdenter: List<String>): String {
+        logger.info("Oppretter utflyttingshendlse e2e")
+        val hendelseId = UUID.randomUUID().toString()
+        val pdlHendelse = PdlHendelse(
+                offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = personIdenter.first { it.length == 13 },
+                hendelseId = hendelseId,
+                personIdenter = personIdenter,
+                endringstype = LeesahService.OPPRETTET,
+                opplysningstype = LeesahService.OPPLYSNINGSTYPE_UTFLYTTING,
+                utflyttingsdato = LocalDate.now())
+
+        leesahService.prosesserNyHendelse(pdlHendelse)
+        return hendelseId
+    }
 
     @PostMapping(path = ["/journal"])
     fun opprettJournalHendelse(@RequestBody journalpost: Journalpost): String {

--- a/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/LeesahConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/LeesahConsumer.kt
@@ -31,8 +31,9 @@ class LeesahConsumer(val leesahService: LeesahService) {
                    idIsGroup = false,
                    containerFactory = "kafkaLeesahListenerContainerFactory")
     @Transactional
-    fun listen(cr: ConsumerRecord<Int, Personhendelse>, ack: Acknowledgment) {
+    fun listen(cr: ConsumerRecord<String, Personhendelse>, ack: Acknowledgment) {
         val pdlHendelse = PdlHendelse(cr.value().hentHendelseId(),
+                                      cr.key(),
                                       cr.offset(),
                                       cr.value().hentOpplysningstype(),
                                       cr.value().hentEndringstype(),

--- a/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/LeesahConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/LeesahConsumer.kt
@@ -42,7 +42,7 @@ class LeesahConsumer(val leesahService: LeesahService) {
                                       cr.value().hentFødselsdato(),
                                       cr.value().hentFødeland(),
                                       cr.value().hentUtflyttingsdato(),
-        )
+        ).also { validerGjeldendeAktørId(it) }
 
         try {
             MDC.put(MDCConstants.MDC_CALL_ID, pdlHendelse.hendelseId)
@@ -57,6 +57,14 @@ class LeesahConsumer(val leesahService: LeesahService) {
         }
 
         ack.acknowledge()
+    }
+
+    private fun validerGjeldendeAktørId(pdlHendelse: PdlHendelse) {
+        if (pdlHendelse.gjeldendeAktørId.length != 13 || !pdlHendelse.personIdenter.contains(pdlHendelse.gjeldendeAktørId)) {
+           leesahFeiletCounter.increment()
+           SECURE_LOGGER.error("Validering av cr.key() som gjeldende aktørId feilet. $pdlHendelse")
+           throw RuntimeException("Validering av cr.key() som gjeldende aktørId feilet")
+        }
     }
 
     private fun GenericRecord.hentOpplysningstype() =

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -85,12 +85,17 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
 
 data class RestFagsak(val id: Long,
                       val behandlinger: List<RestUtvidetBehandling>)
+
 data class RestUtvidetBehandling(val aktiv: Boolean,
                                  val arbeidsfordelingPåBehandling: RestArbeidsfordelingPåBehandling,
                                  val behandlingId: Long,
                                  val kategori: BehandlingKategori,
                                  val opprettetTidspunkt: LocalDateTime,
+                                 val resultat: String,
+                                 val steg: String,
+                                 val type: String,
                                  val underkategori: BehandlingUnderkategori,)
+
 data class RestArbeidsfordelingPåBehandling(
         val behandlendeEnhetId: String,
 )
@@ -111,13 +116,21 @@ data class RestSøkParam(
 )
 
 data class RestFagsakDeltager(
-        var ident: String,
-        var rolle: FagsakDeltagerRolle,
-        var fagsakId: Long,
+        val ident: String,
+        val rolle: FagsakDeltagerRolle,
+        val fagsakId: Long,
+        val fagsakStatus: FagsakStatus,
+
 )
 
 enum class FagsakDeltagerRolle {
     BARN,
     FORELDER,
     UKJENT
+}
+
+enum class FagsakStatus {
+    OPPRETTET,
+    LØPENDE, // Har minst én behandling gjeldende for fremtidig utbetaling
+    AVSLUTTET
 }

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -52,7 +52,7 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
 
     fun hentRestFagsakDeltagerListe(personIdent: String,
                                     barnasIdenter: List<String> = emptyList()): List<RestFagsakDeltager> {
-        val uri = URI.create("$sakServiceUri/fagsaker/sok/fagsakdeltagere-for-ba-mottak")
+        val uri = URI.create("$sakServiceUri/sok/fagsakdeltagere")
         return runCatching {
             postForEntity<Ressurs<List<RestFagsakDeltager>>>(uri, RestSøkParam(personIdent, barnasIdenter))
         }.fold(

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -52,7 +52,7 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
 
     fun hentRestFagsakDeltagerListe(personIdent: String,
                                     barnasIdenter: List<String> = emptyList()): List<RestFagsakDeltager> {
-        val uri = URI.create("$sakServiceUri/sok/fagsakdeltagere")
+        val uri = URI.create("$sakServiceUri/fagsaker/sok/fagsakdeltagere")
         return runCatching {
             postForEntity<Ressurs<List<RestFagsakDeltager>>>(uri, RestSøkParam(personIdent, barnasIdenter))
         }.fold(

--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/SakClient.kt
@@ -57,7 +57,7 @@ class SakClient @Autowired constructor(@param:Value("\${FAMILIE_BA_SAK_API_URL}"
             postForEntity<Ressurs<List<RestFagsakDeltager>>>(uri, RestSøkParam(personIdent, barnasIdenter))
         }.fold(
                 onSuccess = { it.data ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
-                onFailure = { throw IntegrasjonException("", it, uri, personIdent) }
+                onFailure = { throw IntegrasjonException("Feil ved henting av fagsakdeltagere fra ba-sak.", it, uri, personIdent) }
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ba.mottak.integrasjoner.AktørClient
 import no.nav.familie.ba.mottak.integrasjoner.BehandlesAvApplikasjon
 import no.nav.familie.ba.mottak.integrasjoner.BehandlingKategori
 import no.nav.familie.ba.mottak.integrasjoner.BehandlingUnderkategori
+import no.nav.familie.ba.mottak.integrasjoner.FagsakStatus.AVSLUTTET
 import no.nav.familie.ba.mottak.integrasjoner.Familierelasjonsrolle
 import no.nav.familie.ba.mottak.integrasjoner.OppgaveClient
 import no.nav.familie.ba.mottak.integrasjoner.OppgaveVurderLivshendelseDto
@@ -92,7 +93,7 @@ class VurderLivshendelseTask(
                 familierelasjon.filter { it.minRolleForPerson != Familierelasjonsrolle.BARN }
                         .map { it.relatertPersonsIdent }
         if (listeMedBarn.isNotEmpty()) {
-            sakClient.hentRestFagsakDeltagerListe(personIdent).apply { personerMedSak.addAll(this)}
+            personerMedSak += sakClient.hentRestFagsakDeltagerListe(personIdent).filter { it.fagsakStatus != AVSLUTTET }
         }
 
         //Sjekker om foreldrene til person under 19 har en løpende sak.
@@ -104,7 +105,7 @@ class VurderLivshendelseTask(
                             .map { it.relatertPersonsIdent }
 
             listeMedForeldreForBarn.forEach {
-                sakClient.hentRestFagsakDeltagerListe(it).apply { personerMedSak.addAll(this) }
+                personerMedSak += sakClient.hentRestFagsakDeltagerListe(it).filter { it.fagsakStatus != AVSLUTTET }
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
@@ -2,7 +2,18 @@ package no.nav.familie.ba.mottak.task
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
-import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.integrasjoner.AktørClient
+import no.nav.familie.ba.mottak.integrasjoner.BehandlesAvApplikasjon
+import no.nav.familie.ba.mottak.integrasjoner.BehandlingKategori
+import no.nav.familie.ba.mottak.integrasjoner.BehandlingUnderkategori
+import no.nav.familie.ba.mottak.integrasjoner.Familierelasjonsrolle
+import no.nav.familie.ba.mottak.integrasjoner.OppgaveClient
+import no.nav.familie.ba.mottak.integrasjoner.OppgaveVurderLivshendelseDto
+import no.nav.familie.ba.mottak.integrasjoner.PdlClient
+import no.nav.familie.ba.mottak.integrasjoner.PdlPersonData
+import no.nav.familie.ba.mottak.integrasjoner.RestFagsakDeltager
+import no.nav.familie.ba.mottak.integrasjoner.RestUtvidetBehandling
+import no.nav.familie.ba.mottak.integrasjoner.SakClient
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -140,12 +151,11 @@ class VurderLivshendelseTask(
         return if (åpenOppgave != null) {
             Pair(false, åpenOppgave)
         } else {
-            val fagsak = sakClient.hentRestFagsak(fagsakPerson.fagsakId)
-            val restUtvidetBehandling = fagsak.behandlinger.first { it.aktiv }
+            val restUtvidetBehandling = sakClient.hentRestFagsak(fagsakPerson.fagsakId).behandlinger.first { it.aktiv }
 
             Pair(true, OppgaveVurderLivshendelseDto(aktørId = aktørId,
                                                     beskrivelse = beskrivelse,
-                                                    saksId = fagsak.id.toString(),
+                                                    saksId = fagsakPerson.fagsakId.toString(),
                                                     behandlingstema = tilBehandlingstema(restUtvidetBehandling),
                                                     enhetsId = restUtvidetBehandling.arbeidsfordelingPåBehandling.behandlendeEnhetId,
                                                     behandlesAvApplikasjon = BehandlesAvApplikasjon.BA_SAK.applikasjon))

--- a/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTask.kt
@@ -59,7 +59,7 @@ class VurderLivshendelseTask(
             VurderLivshendelseType.UTFLYTTING -> {
                 val pdlPersonData = pdlClient.hentPerson(personIdent, "hentperson-relasjon-utflytting")
                 finnRelatertePersonerMedSak(personIdent, pdlPersonData).forEach {
-                    if (opprettVurderLivshendelseOppgave(it, task, lagUtflyttingoppgavebeskrivelse(it, personIdent))) {
+                    if (opprettVurderLivshendelseOppgave(it, task, lagUtflyttingoppgavebeskrivelse(it.ident, personIdent))) {
                         log.error("Mottatt utflyttingshendelse på sak i BA-sak. Få saksbehandler til å se på oppgave av typen VurderLivshendelse") //TODO midlertidig error logg til man har fått dette inn i saksbehandlersrutinen.
                         oppgaveOpprettetUtflyttingCounter.increment()
                     }
@@ -71,9 +71,9 @@ class VurderLivshendelseTask(
 
 
     private fun finnRelatertePersonerMedSak(personIdent: String,
-                                            pdlPersonData: PdlPersonData): Set<String> {
+                                            pdlPersonData: PdlPersonData): Set<RestFagsakDeltager> {
 
-        val personerMedSak = mutableSetOf<String>()
+        val personerMedSak = mutableSetOf<RestFagsakDeltager>()
 
         val familierelasjon = pdlPersonData.forelderBarnRelasjon
         //populerer en liste med barn for person. Hvis person har barn, så sjekker man etter løpende sak
@@ -81,7 +81,7 @@ class VurderLivshendelseTask(
                 familierelasjon.filter { it.minRolleForPerson != Familierelasjonsrolle.BARN }
                         .map { it.relatertPersonsIdent }
         if (listeMedBarn.isNotEmpty()) {
-            sakClient.hentPågåendeSakStatus(personIdent).apply { if (baSak.finnes()) personerMedSak.add(personIdent) }
+            sakClient.hentRestFagsakDeltagerListe(personIdent).apply { personerMedSak.addAll(this)}
         }
 
         //Sjekker om foreldrene til person under 19 har en løpende sak.
@@ -93,7 +93,7 @@ class VurderLivshendelseTask(
                             .map { it.relatertPersonsIdent }
 
             listeMedForeldreForBarn.forEach {
-                sakClient.hentPågåendeSakStatus(it).apply { if (baSak.finnes()) personerMedSak.add(it) }
+                sakClient.hentRestFagsakDeltagerListe(it).apply { personerMedSak.addAll(this) }
             }
         }
 
@@ -104,11 +104,11 @@ class VurderLivshendelseTask(
         return personerMedSak
     }
 
-    private fun opprettVurderLivshendelseOppgave(personIdent: String,
+    private fun opprettVurderLivshendelseOppgave(fagsakPerson: RestFagsakDeltager,
                                                  task: Task,
                                                  beskrivelse: String): Boolean {
 
-        val (nyopprettet, oppgave) = hentEllerOpprettNyOppgaveForPerson(personIdent, beskrivelse)
+        val (nyopprettet, oppgave) = hentEllerOpprettNyOppgaveForPerson(fagsakPerson, beskrivelse)
 
         if (nyopprettet) {
             oppgaveClient.opprettVurderLivshendelseOppgave(oppgave as OppgaveVurderLivshendelseDto).also {
@@ -126,10 +126,10 @@ class VurderLivshendelseTask(
         }
     }
 
-    private fun hentEllerOpprettNyOppgaveForPerson(personIdent: String,
+    private fun hentEllerOpprettNyOppgaveForPerson(fagsakPerson: RestFagsakDeltager,
                                                    beskrivelse: String): Pair<Boolean, Any> {
 
-        val aktørId = aktørClient.hentAktørId(personIdent.trim())
+        val aktørId = aktørClient.hentAktørId(fagsakPerson.ident)
         val vurderLivshendelseOppgaver = oppgaveClient.finnOppgaverPåAktørId(aktørId, Oppgavetype.VurderLivshendelse)
 
         val åpenOppgave: Oppgave? = vurderLivshendelseOppgaver.firstOrNull {
@@ -140,10 +140,10 @@ class VurderLivshendelseTask(
         return if (åpenOppgave != null) {
             Pair(false, åpenOppgave)
         } else {
-            val fagsak = sakClient.hentRestFagsak(personIdent)
+            val fagsak = sakClient.hentRestFagsak(fagsakPerson.fagsakId)
             val restUtvidetBehandling = fagsak.behandlinger.first { it.aktiv }
 
-            Pair(true, OppgaveVurderLivshendelseDto(aktørId = aktørClient.hentAktørId(personIdent.trim()),
+            Pair(true, OppgaveVurderLivshendelseDto(aktørId = aktørId,
                                                     beskrivelse = beskrivelse,
                                                     saksId = fagsak.id.toString(),
                                                     behandlingstema = tilBehandlingstema(restUtvidetBehandling),
@@ -161,8 +161,8 @@ class VurderLivshendelseTask(
         }
     }
 
-    private fun lagUtflyttingoppgavebeskrivelse(bruker: String, utflyttetPerson: String) =
-            BESKRIVELSE_UTFLYTTING.format(if (utflyttetPerson == bruker) "bruker" else "barn $utflyttetPerson")
+    private fun lagUtflyttingoppgavebeskrivelse(fagsakPerson: String, utflyttetPerson: String) =
+            BESKRIVELSE_UTFLYTTING.format(if (utflyttetPerson == fagsakPerson) "bruker" else "barn $utflyttetPerson")
 
     companion object {
 

--- a/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -222,8 +222,8 @@ class JournalføringHendelseServiceTest {
         } returns "12345678910"
 
         every {
-            sakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse(baSak = Sakspart.SØKER)
+            sakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns listOf(RestFagsakDeltager("12345678910", FagsakDeltagerRolle.FORELDER, 1L))
 
         every {
             infotrygdBarnetrygdClient.hentLøpendeUtbetalinger(any(), any())

--- a/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -1,13 +1,29 @@
 package no.nav.familie.ba.mottak.hendelser
 
-import io.mockk.*
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.familie.ba.mottak.config.FeatureToggleService
 import no.nav.familie.ba.mottak.domene.HendelseConsumer
 import no.nav.familie.ba.mottak.domene.Hendelseslogg
 import no.nav.familie.ba.mottak.domene.HendelsesloggRepository
-import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.integrasjoner.AktørClient
+import no.nav.familie.ba.mottak.integrasjoner.Bruker
+import no.nav.familie.ba.mottak.integrasjoner.BrukerIdType
+import no.nav.familie.ba.mottak.integrasjoner.FagsakDeltagerRolle.FORELDER
+import no.nav.familie.ba.mottak.integrasjoner.FagsakStatus.LØPENDE
+import no.nav.familie.ba.mottak.integrasjoner.InfotrygdBarnetrygdClient
+import no.nav.familie.ba.mottak.integrasjoner.Journalpost
+import no.nav.familie.ba.mottak.integrasjoner.JournalpostClient
+import no.nav.familie.ba.mottak.integrasjoner.Journalposttype
+import no.nav.familie.ba.mottak.integrasjoner.Journalstatus
+import no.nav.familie.ba.mottak.integrasjoner.OppgaveClient
+import no.nav.familie.ba.mottak.integrasjoner.RestFagsakDeltager
+import no.nav.familie.ba.mottak.integrasjoner.SakClient
 import no.nav.familie.ba.mottak.task.JournalhendelseRutingTask
 import no.nav.familie.ba.mottak.task.OpprettJournalføringOppgaveTask
 import no.nav.familie.ba.mottak.task.SendTilSakTask
@@ -223,7 +239,7 @@ class JournalføringHendelseServiceTest {
 
         every {
             sakClient.hentRestFagsakDeltagerListe(any(), emptyList())
-        } returns listOf(RestFagsakDeltager("12345678910", FagsakDeltagerRolle.FORELDER, 1L))
+        } returns listOf(RestFagsakDeltager("12345678910", FORELDER, 1L, LØPENDE))
 
         every {
             infotrygdBarnetrygdClient.hentLøpendeUtbetalinger(any(), any())

--- a/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/LeesahServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/hendelser/LeesahServiceTest.kt
@@ -42,6 +42,7 @@ class LeesahServiceTest {
         val hendelseId = UUID.randomUUID().toString()
         val pdlHendelse = PdlHendelse(
                 offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = "1234567890123",
                 hendelseId = hendelseId,
                 personIdenter = listOf("12345678901", "1234567890123"),
                 endringstype = LeesahService.OPPRETTET,
@@ -68,6 +69,7 @@ class LeesahServiceTest {
         val hendelseId = UUID.randomUUID().toString()
         val pdlHendelse = PdlHendelse(
                 offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = "1234567890123",
                 hendelseId = hendelseId,
                 personIdenter = listOf("12345678901", "1234567890123"),
                 endringstype = LeesahService.OPPRETTET,
@@ -94,6 +96,7 @@ class LeesahServiceTest {
         val hendelseId = UUID.randomUUID().toString()
         val pdlHendelse = PdlHendelse(
                 offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = "1234567890123",
                 hendelseId = hendelseId,
                 personIdenter = listOf("12345678901", "1234567890123"),
                 endringstype = LeesahService.OPPRETTET,
@@ -122,6 +125,7 @@ class LeesahServiceTest {
         val hendelseId = UUID.randomUUID().toString()
         val pdlHendelse = PdlHendelse(
                 offset = Random.nextUInt().toLong(),
+                gjeldendeAktørId = "1234567890123",
                 hendelseId = hendelseId,
                 personIdenter = listOf("12345678901", "1234567890123"),
                 endringstype = LeesahService.OPPRETTET,

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/NavnoHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/NavnoHendelseTaskLøypeTest.kt
@@ -4,8 +4,6 @@ import io.mockk.*
 import no.nav.familie.ba.mottak.integrasjoner.*
 import no.nav.familie.ba.mottak.integrasjoner.Opphørsgrunn.MIGRERT
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
-import no.nav.familie.kontrakter.ba.infotrygd.Stønad as StønadDto
-import no.nav.familie.kontrakter.ba.infotrygd.Sak as SakDto
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.assertj.core.api.Assertions
@@ -13,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.LocalDate
+import no.nav.familie.kontrakter.ba.infotrygd.Sak as SakDto
+import no.nav.familie.kontrakter.ba.infotrygd.Stønad as StønadDto
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class NavnoHendelseTaskLøypeTest {
@@ -61,8 +61,8 @@ class NavnoHendelseTaskLøypeTest {
         } returns listOf()
 
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse()
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns emptyList()
 
         every {
             mockInfotrygdBarnetrygdClient.hentLøpendeUtbetalinger(any(), any())
@@ -76,8 +76,8 @@ class NavnoHendelseTaskLøypeTest {
     @Test
     fun `Skal opprette JFR-oppgave med tekst om at bruker har sak i BA-sak`() {
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse(baSak = Sakspart.SØKER)
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns listOf(RestFagsakDeltager("12345678901", FagsakDeltagerRolle.FORELDER, FAGSAK_ID.toLong()))
 
         every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
 
@@ -97,8 +97,8 @@ class NavnoHendelseTaskLøypeTest {
     @Test
     fun `Skal ikke gå videre når bruker ikke har sak i BA-sak`() {
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse()
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns emptyList()
 
         Assertions.assertThatThrownBy {
             kjørRutingTaskOgReturnerNesteTask()
@@ -119,8 +119,8 @@ class NavnoHendelseTaskLøypeTest {
     @Test
     fun `Skal opprette JFR-oppgave med tekst om at bruker har sak begge steder`() {
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse(baSak = Sakspart.SØKER)
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns listOf(RestFagsakDeltager("12345678901", FagsakDeltagerRolle.FORELDER, FAGSAK_ID.toLong()))
 
         every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
 
@@ -141,8 +141,8 @@ class NavnoHendelseTaskLøypeTest {
     @Test
     fun `Skal opprette JFR-oppgave med henvisning til BA-sak når bruker er migrert fra Infotrygd`() {
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse(baSak = Sakspart.SØKER)
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns listOf(RestFagsakDeltager("12345678901", FagsakDeltagerRolle.FORELDER, FAGSAK_ID.toLong()))
 
         every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
 

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/NavnoHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/NavnoHendelseTaskLøypeTest.kt
@@ -1,8 +1,25 @@
 package no.nav.familie.ba.mottak.task
 
-import io.mockk.*
-import no.nav.familie.ba.mottak.integrasjoner.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ba.mottak.integrasjoner.Bruker
+import no.nav.familie.ba.mottak.integrasjoner.BrukerIdType
+import no.nav.familie.ba.mottak.integrasjoner.FagsakDeltagerRolle.FORELDER
+import no.nav.familie.ba.mottak.integrasjoner.FagsakStatus.LØPENDE
+import no.nav.familie.ba.mottak.integrasjoner.InfotrygdBarnetrygdClient
+import no.nav.familie.ba.mottak.integrasjoner.Journalpost
+import no.nav.familie.ba.mottak.integrasjoner.JournalpostClient
+import no.nav.familie.ba.mottak.integrasjoner.Journalposttype
+import no.nav.familie.ba.mottak.integrasjoner.Journalstatus
+import no.nav.familie.ba.mottak.integrasjoner.OppgaveClient
 import no.nav.familie.ba.mottak.integrasjoner.Opphørsgrunn.MIGRERT
+import no.nav.familie.ba.mottak.integrasjoner.PdlClient
+import no.nav.familie.ba.mottak.integrasjoner.RestFagsakDeltager
+import no.nav.familie.ba.mottak.integrasjoner.SakClient
+import no.nav.familie.ba.mottak.integrasjoner.StatusKode
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -77,7 +94,7 @@ class NavnoHendelseTaskLøypeTest {
     fun `Skal opprette JFR-oppgave med tekst om at bruker har sak i BA-sak`() {
         every {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
-        } returns listOf(RestFagsakDeltager("12345678901", FagsakDeltagerRolle.FORELDER, FAGSAK_ID.toLong()))
+        } returns listOf(RestFagsakDeltager("12345678901", FORELDER, FAGSAK_ID.toLong(), LØPENDE))
 
         every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
 
@@ -120,7 +137,7 @@ class NavnoHendelseTaskLøypeTest {
     fun `Skal opprette JFR-oppgave med tekst om at bruker har sak begge steder`() {
         every {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
-        } returns listOf(RestFagsakDeltager("12345678901", FagsakDeltagerRolle.FORELDER, FAGSAK_ID.toLong()))
+        } returns listOf(RestFagsakDeltager("12345678901", FORELDER, FAGSAK_ID.toLong(), LØPENDE))
 
         every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
 
@@ -142,7 +159,7 @@ class NavnoHendelseTaskLøypeTest {
     fun `Skal opprette JFR-oppgave med henvisning til BA-sak når bruker er migrert fra Infotrygd`() {
         every {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
-        } returns listOf(RestFagsakDeltager("12345678901", FagsakDeltagerRolle.FORELDER, FAGSAK_ID.toLong()))
+        } returns listOf(RestFagsakDeltager("12345678901", FORELDER, FAGSAK_ID.toLong(), LØPENDE))
 
         every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
 

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/SkanHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/SkanHendelseTaskLøypeTest.kt
@@ -1,8 +1,26 @@
 package no.nav.familie.ba.mottak.task
 
-import io.mockk.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.familie.ba.mottak.hendelser.JournalføringHendelseServiceTest
-import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.integrasjoner.AktørClient
+import no.nav.familie.ba.mottak.integrasjoner.Bruker
+import no.nav.familie.ba.mottak.integrasjoner.BrukerIdType
+import no.nav.familie.ba.mottak.integrasjoner.FagsakDeltagerRolle.BARN
+import no.nav.familie.ba.mottak.integrasjoner.FagsakDeltagerRolle.FORELDER
+import no.nav.familie.ba.mottak.integrasjoner.FagsakStatus.LØPENDE
+import no.nav.familie.ba.mottak.integrasjoner.InfotrygdBarnetrygdClient
+import no.nav.familie.ba.mottak.integrasjoner.Journalpost
+import no.nav.familie.ba.mottak.integrasjoner.JournalpostClient
+import no.nav.familie.ba.mottak.integrasjoner.Journalposttype
+import no.nav.familie.ba.mottak.integrasjoner.Journalstatus
+import no.nav.familie.ba.mottak.integrasjoner.OppgaveClient
+import no.nav.familie.ba.mottak.integrasjoner.PdlClient
+import no.nav.familie.ba.mottak.integrasjoner.RestFagsakDeltager
+import no.nav.familie.ba.mottak.integrasjoner.SakClient
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.prosessering.domene.Task
@@ -87,7 +105,7 @@ class SkanHendelseTaskLøypeTest {
 
         every {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
-        } returns listOf(RestFagsakDeltager("12345678910", FagsakDeltagerRolle.FORELDER, 1L))
+        } returns listOf(RestFagsakDeltager("12345678910", FORELDER, 1L, LØPENDE))
 
         kjørRutingTaskOgReturnerNesteTask().run {
             journalføringSteg.doTask(this)
@@ -104,7 +122,7 @@ class SkanHendelseTaskLøypeTest {
 
         every {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
-        } returns listOf(RestFagsakDeltager("12345678910", FagsakDeltagerRolle.BARN, 1L))
+        } returns listOf(RestFagsakDeltager("12345678910", BARN, 1L, LØPENDE))
 
         kjørRutingTaskOgReturnerNesteTask().run {
             journalføringSteg.doTask(this)

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/SkanHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/SkanHendelseTaskLøypeTest.kt
@@ -4,8 +4,6 @@ import io.mockk.*
 import no.nav.familie.ba.mottak.hendelser.JournalføringHendelseServiceTest
 import no.nav.familie.ba.mottak.integrasjoner.*
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
-import no.nav.familie.kontrakter.ba.infotrygd.Stønad as StønadDto
-import no.nav.familie.kontrakter.ba.infotrygd.Sak as SakDto
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -13,6 +11,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import no.nav.familie.kontrakter.ba.infotrygd.Sak as SakDto
+import no.nav.familie.kontrakter.ba.infotrygd.Stønad as StønadDto
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SkanHendelseTaskLøypeTest {
@@ -65,8 +65,8 @@ class SkanHendelseTaskLøypeTest {
         } returns "12345678910"
 
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse()
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns emptyList()
 
         every {
             mockInfotrygdBarnetrygdClient.hentLøpendeUtbetalinger(any(), any())
@@ -86,8 +86,8 @@ class SkanHendelseTaskLøypeTest {
         } returns OppgaveResponse(1)
 
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse(baSak = Sakspart.SØKER)
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns listOf(RestFagsakDeltager("12345678910", FagsakDeltagerRolle.FORELDER, 1L))
 
         kjørRutingTaskOgReturnerNesteTask().run {
             journalføringSteg.doTask(this)
@@ -103,8 +103,8 @@ class SkanHendelseTaskLøypeTest {
         } returns OppgaveResponse(1)
 
         every {
-            mockSakClient.hentPågåendeSakStatus(any(), emptyList())
-        } returns RestPågåendeSakResponse(baSak = Sakspart.ANNEN)
+            mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
+        } returns listOf(RestFagsakDeltager("12345678910", FagsakDeltagerRolle.BARN, 1L))
 
         kjørRutingTaskOgReturnerNesteTask().run {
             journalføringSteg.doTask(this)

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTaskTest.kt
@@ -5,6 +5,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ba.mottak.integrasjoner.*
+import no.nav.familie.ba.mottak.integrasjoner.FagsakDeltagerRolle.FORELDER
+import no.nav.familie.ba.mottak.integrasjoner.FagsakStatus.LØPENDE
 import no.nav.familie.ba.mottak.task.VurderLivshendelseType.DØDSFALL
 import no.nav.familie.ba.mottak.task.VurderLivshendelseType.UTFLYTTING
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -178,7 +180,7 @@ class VurderLivshendelseTaskTest {
         )
 
         every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, emptyList()) } returns
-                listOf(RestFagsakDeltager(PERSONIDENT_MOR, FagsakDeltagerRolle.FORELDER, SAKS_ID))
+                listOf(RestFagsakDeltager(PERSONIDENT_MOR, FORELDER, SAKS_ID, LØPENDE))
 
         every { mockSakClient.hentRestFagsak(SAKS_ID) } returns lagAktivOrdinær()
 
@@ -239,7 +241,7 @@ class VurderLivshendelseTaskTest {
 
 
         every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, emptyList()) } returns
-                listOf(RestFagsakDeltager(PERSONIDENT_MOR, FagsakDeltagerRolle.FORELDER, SAKS_ID))
+                listOf(RestFagsakDeltager(PERSONIDENT_MOR, FORELDER, SAKS_ID, LØPENDE))
 
         every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_FAR, emptyList()) } returns emptyList()
 
@@ -285,6 +287,9 @@ class VurderLivshendelseTaskTest {
                 321,
                 BehandlingKategori.NASJONAL,
                 LocalDateTime.now(),
+                "RESULTAT",
+                "STEG",
+                "TYPE",
                 BehandlingUnderkategori.ORDINÆR
             )
         )
@@ -299,6 +304,9 @@ class VurderLivshendelseTaskTest {
                 321,
                 BehandlingKategori.NASJONAL,
                 LocalDateTime.now(),
+                "RESULTAT",
+                "STEG",
+                "TYPE",
                 BehandlingUnderkategori.UTVIDET
             )
         )

--- a/src/test/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/mottak/task/VurderLivshendelseTaskTest.kt
@@ -106,9 +106,9 @@ class VurderLivshendelseTaskTest {
         verify(exactly = 0) {
             mockTaskRepository.saveAndFlush(any())
             mockOppgaveClient.opprettVurderLivshendelseOppgave(any())
-            mockSakClient.hentPågåendeSakStatus(PERSONIDENT_BARN, listOf())
-            mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, listOf(PERSONIDENT_BARN))
-            mockSakClient.hentPågåendeSakStatus(PERSONIDENT_FAR, listOf(PERSONIDENT_BARN))
+            mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_BARN, listOf())
+            mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, listOf(PERSONIDENT_BARN))
+            mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_FAR, listOf(PERSONIDENT_BARN))
         }
 
     }
@@ -132,7 +132,7 @@ class VurderLivshendelseTaskTest {
             dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now()))
         )
 
-        every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, emptyList()) } returns RestPågåendeSakResponse()
+        every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, emptyList()) } returns emptyList()
 
         listOf(UTFLYTTING, DØDSFALL).forEach {
             vurderLivshendelseTask.doTask(
@@ -154,7 +154,7 @@ class VurderLivshendelseTaskTest {
         }
 
         verify(exactly = 2) {
-            mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, emptyList())
+            mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, emptyList())
         }
     }
 
@@ -177,10 +177,10 @@ class VurderLivshendelseTaskTest {
             dødsfall = listOf(Dødsfall(dødsdato = LocalDate.now()))
         )
 
-        every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, emptyList()) } returns RestPågåendeSakResponse(
-            baSak = Sakspart.SØKER
-        )
-        every { mockSakClient.hentRestFagsak(PERSONIDENT_MOR) } returns lagAktivOrdinær()
+        every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, emptyList()) } returns
+                listOf(RestFagsakDeltager(PERSONIDENT_MOR, FagsakDeltagerRolle.FORELDER, SAKS_ID))
+
+        every { mockSakClient.hentRestFagsak(SAKS_ID) } returns lagAktivOrdinær()
 
         listOf(DØDSFALL, UTFLYTTING).forEach {
             vurderLivshendelseTask.doTask(
@@ -206,7 +206,7 @@ class VurderLivshendelseTaskTest {
         assertThat(oppgaveDto[1].beskrivelse).isEqualTo(VurderLivshendelseTask.BESKRIVELSE_UTFLYTTING.format("bruker"))
 
         assertThat(oppgaveDto).allMatch { it.aktørId.contains(PERSONIDENT_MOR) }
-        assertThat(oppgaveDto).allMatch { it.saksId == SAKS_ID }
+        assertThat(oppgaveDto).allMatch { it.saksId == "$SAKS_ID"  }
         assertThat(oppgaveDto).allMatch { it.enhetsId == ENHET_ID }
         assertThat(oppgaveDto).allMatch { it.behandlingstema == Behandlingstema.OrdinærBarnetrygd.value }
         assertThat(oppgaveDto).allMatch { it.behandlesAvApplikasjon == BehandlesAvApplikasjon.BA_SAK.applikasjon }
@@ -238,13 +238,12 @@ class VurderLivshendelseTaskTest {
         )
 
 
-        every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_MOR, emptyList()) } returns RestPågåendeSakResponse(
-            baSak = Sakspart.SØKER
-        )
-        every { mockSakClient.hentPågåendeSakStatus(PERSONIDENT_FAR, emptyList()) } returns RestPågåendeSakResponse(
-            baSak = null
-        )
-        every { mockSakClient.hentRestFagsak(PERSONIDENT_MOR) } returns lagAktivUtvidet()
+        every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_MOR, emptyList()) } returns
+                listOf(RestFagsakDeltager(PERSONIDENT_MOR, FagsakDeltagerRolle.FORELDER, SAKS_ID))
+
+        every { mockSakClient.hentRestFagsakDeltagerListe(PERSONIDENT_FAR, emptyList()) } returns emptyList()
+
+        every { mockSakClient.hentRestFagsak(SAKS_ID) } returns lagAktivUtvidet()
 
         listOf(DØDSFALL, UTFLYTTING).forEach {
             vurderLivshendelseTask.doTask(
@@ -270,7 +269,7 @@ class VurderLivshendelseTaskTest {
         assertThat(oppgaveDto[1].beskrivelse).isEqualTo(VurderLivshendelseTask.BESKRIVELSE_UTFLYTTING.format("barn $PERSONIDENT_BARN"))
 
         assertThat(oppgaveDto).allMatch { it.aktørId.contains(PERSONIDENT_MOR) }
-        assertThat(oppgaveDto).allMatch { it.saksId == SAKS_ID }
+        assertThat(oppgaveDto).allMatch { it.saksId == "$SAKS_ID" }
         assertThat(oppgaveDto).allMatch { it.enhetsId == ENHET_ID }
         assertThat(oppgaveDto).allMatch { it.behandlingstema == Behandlingstema.UtvidetBarnetrygd.value }
         assertThat(oppgaveDto).allMatch { it.behandlesAvApplikasjon == BehandlesAvApplikasjon.BA_SAK.applikasjon }
@@ -278,8 +277,8 @@ class VurderLivshendelseTaskTest {
 
 
     private fun lagAktivOrdinær() = RestFagsak(
-        SAKS_ID.toLong(),
-        listOf(
+            SAKS_ID,
+            listOf(
             RestUtvidetBehandling(
                 true,
                 RestArbeidsfordelingPåBehandling(ENHET_ID),
@@ -311,7 +310,7 @@ class VurderLivshendelseTaskTest {
         private val PERSONIDENT_BARN = "12345654321"
         private val PERSONIDENT_MOR = "12345678901"
         private val PERSONIDENT_FAR = "12345678888"
-        private val SAKS_ID = "123"
+        private val SAKS_ID = 123L
         private val ENHET_ID = "3049"
     }
 }


### PR DESCRIPTION
Samt tar vare på "gjeldendeAktørId", som finnes i cr.key(), i PdlHendelse.