### PR TITLE
(fix) Logg utvida søknader til grafana korrekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/søknad/SøknadController.kt
@@ -3,13 +3,10 @@ package no.nav.familie.ba.mottak.søknad
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ba.mottak.config.FeatureToggleService
 import no.nav.familie.ba.mottak.søknad.domene.FødselsnummerErNullException
-import no.nav.familie.kontrakter.ba.Søknadstype
+import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import no.nav.familie.kontrakter.ba.søknad.v4.Dokumentasjonsbehov
-import no.nav.familie.kontrakter.ba.søknad.v3.Dokumentasjonsbehov as DokumentasjonsbehovV3
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknad
-import no.nav.familie.kontrakter.ba.søknad.v3.Søknad as SøknadV3
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsvedlegg
-import no.nav.familie.kontrakter.ba.søknad.v3.Søknadsvedlegg as SøknadsvedleggV3
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
@@ -54,64 +51,7 @@ class SøknadController(
     val utvidetHarManglerIDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.harManglerIDokumentasjonsbehov")
 
     @PostMapping(value = ["/soknad/v4"], consumes = [MULTIPART_FORM_DATA_VALUE])
-    fun taImotSøknad(@RequestPart("søknad") søknad: Søknad): ResponseEntity<Ressurs<Kvittering>> {
-        val lagreSøknad = featureToggleService.isEnabled("familie-ba-mottak.lagre-soknad")
-        log.info("Lagring av søknad = $lagreSøknad")
-
-        return if (lagreSøknad) {
-            try {
-                val dbSøknad = søknadService.motta(søknad)
-
-                sendMetrics(søknad)
-
-                ResponseEntity.ok(Ressurs.success(Kvittering("Søknad er mottatt", dbSøknad.opprettetTid)))
-            } catch (e: FødselsnummerErNullException) {
-                søknadMottattFeil.increment()
-                ResponseEntity.status(500).body(Ressurs.failure("Lagring av søknad feilet"))
-            }
-        } else {
-            ResponseEntity.ok(
-                Ressurs.success(
-                    Kvittering(
-                        "Søknad er mottatt. Lagring er deaktivert.",
-                        LocalDateTime.now()
-                    )
-                )
-            )
-        }
-    }
-
-    private fun sendMetrics(søknad: Søknad) {
-        søknadMottattOk.increment()
-
-        if (søknad.dokumentasjon.isNotEmpty()) {
-            // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
-            val dokumentasjonsbehovUtenAnnenDokumentasjon =
-                søknad.dokumentasjon.filter { it.dokumentasjonsbehov != Dokumentasjonsbehov.ANNEN_DOKUMENTASJON }
-            if (dokumentasjonsbehovUtenAnnenDokumentasjon.isNotEmpty()) {
-                søknadHarDokumentasjonsbehov.increment()
-                antallDokumentasjonsbehov.increment(dokumentasjonsbehovUtenAnnenDokumentasjon.size.toDouble())
-            }
-
-            // Inkluderer Dokumentasjonsbehov.ANNEN_DOKUMENTASJON for søknadHarVedlegg og antallVedlegg
-            val alleVedlegg: List<Søknadsvedlegg> = søknad.dokumentasjon.map { it.opplastedeVedlegg }.flatten()
-            if (alleVedlegg.isNotEmpty()) {
-                søknadHarVedlegg.increment()
-                antallVedlegg.increment(alleVedlegg.size.toDouble())
-            }
-
-            // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
-            val harMangler =
-                dokumentasjonsbehovUtenAnnenDokumentasjon.filter { !it.harSendtInn && it.opplastedeVedlegg.isEmpty() }
-                    .isNotEmpty()
-            if (harMangler) {
-                harManglerIDokumentasjonsbehov.increment()
-            }
-        }
-    }
-
-    @PostMapping(value = ["/soknad/v3"], consumes = [MULTIPART_FORM_DATA_VALUE])
-    fun taImotSøknadV3(@RequestPart("søknad") søknad: SøknadV3): ResponseEntity<Ressurs<Kvittering>> {
+    fun taImotSøknadV3(@RequestPart("søknad") søknad: Søknad): ResponseEntity<Ressurs<Kvittering>> {
         val lagreSøknad = featureToggleService.isEnabled("familie-ba-mottak.lagre-soknad")
         log.info("Lagring av søknad = $lagreSøknad")
 
@@ -141,10 +81,10 @@ class SøknadController(
         }
     }
 
-    private fun sendMetricsAntallVedlegg(søknad: SøknadV3) {
+    private fun sendMetricsAntallVedlegg(søknad: Søknad) {
         val erUtvidet = søknad.søknadstype == Søknadstype.UTVIDET
         // Inkluderer Dokumentasjonsbehov.ANNEN_DOKUMENTASJON for søknadHarVedlegg og antallVedlegg
-        val alleVedlegg: List<SøknadsvedleggV3> = søknad.dokumentasjon.map { it.opplastedeVedlegg }.flatten()
+        val alleVedlegg: List<Søknadsvedlegg> = søknad.dokumentasjon.map { it.opplastedeVedlegg }.flatten()
         if (alleVedlegg.isNotEmpty()) {
             if (erUtvidet) {
                 utvidetSøknadHarVedlegg.increment()
@@ -156,13 +96,13 @@ class SøknadController(
         }
     }
 
-    private fun sendMetrics(søknad: SøknadV3) {
+    private fun sendMetrics(søknad: Søknad) {
         val erUtvidet = søknad.søknadstype == Søknadstype.UTVIDET
         if (erUtvidet) søknadUtvidetMottattOk.increment() else søknadMottattOk.increment()
         if (søknad.dokumentasjon.isNotEmpty()) {
             // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
             val dokumentasjonsbehovUtenAnnenDokumentasjon =
-                søknad.dokumentasjon.filter { it.dokumentasjonsbehov != DokumentasjonsbehovV3.ANNEN_DOKUMENTASJON }
+                søknad.dokumentasjon.filter { it.dokumentasjonsbehov != Dokumentasjonsbehov.ANNEN_DOKUMENTASJON }
             if (dokumentasjonsbehovUtenAnnenDokumentasjon.isNotEmpty()) {
                 if (erUtvidet) {
                     utvidetSøknadHarDokumentasjonsbehov.increment()

--- a/src/main/kotlin/no/nav/familie/ba/mottak/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/søknad/SøknadController.kt
@@ -51,7 +51,7 @@ class SøknadController(
     val utvidetHarManglerIDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.harManglerIDokumentasjonsbehov")
 
     @PostMapping(value = ["/soknad/v4"], consumes = [MULTIPART_FORM_DATA_VALUE])
-    fun taImotSøknadV3(@RequestPart("søknad") søknad: Søknad): ResponseEntity<Ressurs<Kvittering>> {
+    fun taImotSøknad(@RequestPart("søknad") søknad: Søknad): ResponseEntity<Ressurs<Kvittering>> {
         val lagreSøknad = featureToggleService.isEnabled("familie-ba-mottak.lagre-soknad")
         log.info("Lagring av søknad = $lagreSøknad")
 

--- a/src/main/kotlin/no/nav/familie/ba/mottak/søknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/søknad/SøknadController.kt
@@ -81,21 +81,6 @@ class SøknadController(
         }
     }
 
-    private fun sendMetricsAntallVedlegg(søknad: Søknad) {
-        val erUtvidet = søknad.søknadstype == Søknadstype.UTVIDET
-        // Inkluderer Dokumentasjonsbehov.ANNEN_DOKUMENTASJON for søknadHarVedlegg og antallVedlegg
-        val alleVedlegg: List<Søknadsvedlegg> = søknad.dokumentasjon.map { it.opplastedeVedlegg }.flatten()
-        if (alleVedlegg.isNotEmpty()) {
-            if (erUtvidet) {
-                utvidetSøknadHarVedlegg.increment()
-                utvidetAntallVedlegg.increment(alleVedlegg.size.toDouble())
-            } else {
-                søknadHarVedlegg.increment()
-                antallVedlegg.increment(alleVedlegg.size.toDouble())
-            }
-        }
-    }
-
     private fun sendMetrics(søknad: Søknad) {
         val erUtvidet = søknad.søknadstype == Søknadstype.UTVIDET
         if (erUtvidet) søknadUtvidetMottattOk.increment() else søknadMottattOk.increment()
@@ -120,6 +105,21 @@ class SøknadController(
                     .isNotEmpty()
             if (harMangler) {
                 if (erUtvidet) utvidetHarManglerIDokumentasjonsbehov.increment() else harManglerIDokumentasjonsbehov.increment()
+            }
+        }
+    }
+
+    private fun sendMetricsAntallVedlegg(søknad: Søknad) {
+        val erUtvidet = søknad.søknadstype == Søknadstype.UTVIDET
+        // Inkluderer Dokumentasjonsbehov.ANNEN_DOKUMENTASJON for søknadHarVedlegg og antallVedlegg
+        val alleVedlegg: List<Søknadsvedlegg> = søknad.dokumentasjon.map { it.opplastedeVedlegg }.flatten()
+        if (alleVedlegg.isNotEmpty()) {
+            if (erUtvidet) {
+                utvidetSøknadHarVedlegg.increment()
+                utvidetAntallVedlegg.increment(alleVedlegg.size.toDouble())
+            } else {
+                søknadHarVedlegg.increment()
+                antallVedlegg.increment(alleVedlegg.size.toDouble())
             }
         }
     }


### PR DESCRIPTION
v4-søknader ble behandlet som om de aldri var utvidet. Dette er fikset her, i tillegg til at jeg har fjernet det gamle endpointet for v3-søknader. Resten av v3-koden har jeg latt være for nå i tilfelle noen gamle tasks må rekjøres for whatever reason.