### PR TITLE
Endrer til å bruke RekjørSenereException for motta fødselshendelse, siden save ender med task i evig klar til plukk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/TPSPersonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/integrasjoner/TPSPersonClient.kt
@@ -46,8 +46,8 @@ class TPSPersonClient @Autowired constructor(@param:Value("\${FAMILIE_INTEGRASJO
             if (e is HttpClientErrorException.NotFound) {
                 throw e
             }
-            logger.info("Feil mot TPS. status=${e.statusCode}, stacktrace=${e.stackTrace.toList()}")
-            secureLogger.info("Feil mot TPS. msg=${e.message}, body=${e.responseBodyAsString}")
+            logger.info("Feil mot TPS. status=${e.statusCode}")
+            secureLogger.info("Feil mot TPS. msg=${e.message}, body=${e.responseBodyAsString}", e)
             throw RuntimeException("Kall mot integrasjon feilet ved uthenting av personinfo. ${e.statusCode} ${e.responseBodyAsString}")
         }
     }


### PR DESCRIPTION
Kaster RekjørSenereException ved behov om å kjøre senere i fødselshendelser etter overgang til ny prosesseringsrammeverk. Tasker ender i KLAR_TIL_PLUKK state ved feil ved bruk av save
